### PR TITLE
Conversions for approximations

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -54,7 +54,8 @@ module Calling_convention = struct
 
   let compute ~params_and_body ~is_tupled =
     let f ~return_continuation:_ _exn_continuation params ~body:_ ~my_closure:_
-        ~(is_my_closure_used : _ Or_unknown.t) ~my_depth:_ =
+        ~(is_my_closure_used : _ Or_unknown.t) ~my_depth:_ ~free_names_of_body:_
+        =
       let is_my_closure_used =
         match is_my_closure_used with
         | Unknown -> true

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -19,13 +19,16 @@
 (** Dumping and restoring of simplification environment information to and from
     .cmx files. *)
 
+type loader
+
+val create_loader : (module Flambda_backend_intf.S) -> loader
+
+val get_imported_names : loader -> unit -> Name.Set.t
+
+val get_imported_code : loader -> unit -> Exported_code.t
+
 val load_cmx_file_contents :
-  (module Flambda_backend_intf.S) ->
-  Compilation_unit.t ->
-  imported_units:Flambda_type.Typing_env.t option Compilation_unit.Map.t ref ->
-  imported_names:Name.Set.t ref ->
-  imported_code:Exported_code.t ref ->
-  Flambda_type.Typing_env.t option
+  loader -> Compilation_unit.t -> Flambda_type.Typing_env.t option
 
 val prepare_cmx_file_contents :
   return_cont_env:Continuation_uses_env.t ->

--- a/middle_end/flambda2/cmx/value_approximation.ml
+++ b/middle_end/flambda2/cmx/value_approximation.ml
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*            Pierre Chambart and Vincent Laviron, OCamlPro               *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Approximations used for cross-module inlining in Closure_conversion *)
+
+type t =
+  | Value_unknown
+  | Closure_approximation of Code_id.t * Flambda.Code.t option
+  | Block_approximation of t array
+
+let is_unknown = function
+  | Value_unknown -> true
+  | Closure_approximation _ | Block_approximation _ -> false

--- a/middle_end/flambda2/cmx/value_approximation.mli
+++ b/middle_end/flambda2/cmx/value_approximation.mli
@@ -1,0 +1,26 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*            Pierre Chambart and Vincent Laviron, OCamlPro               *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Approximations used for cross-module inlining in Closure_conversion *)
+
+type t =
+  | Value_unknown
+  | Closure_approximation of Code_id.t * Flambda.Code.t option
+  | Block_approximation of t array
+
+val is_unknown : t -> bool

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -395,11 +395,12 @@ and subst_params_and_body env params_and_body =
          ~my_closure
          ~is_my_closure_used:_
          ~my_depth
+         ~free_names_of_body
        ->
       let body = subst_expr env body in
       let dbg = Function_params_and_body.debuginfo params_and_body in
       Function_params_and_body.create ~return_continuation exn_continuation
-        params ~dbg ~body ~my_closure ~free_names_of_body:Unknown ~my_depth)
+        params ~dbg ~body ~my_closure ~free_names_of_body ~my_depth)
 
 and subst_let_cont env (let_cont_expr : Let_cont_expr.t) =
   match let_cont_expr with

--- a/middle_end/flambda2/flambda_middle_end.ml
+++ b/middle_end/flambda2/flambda_middle_end.ml
@@ -81,6 +81,10 @@ let middle_end0 ppf ~prefixname ~backend ~filename ~module_ident
               ~module_block_size_in_words module_initializer)
       in
       print_rawflambda ppf flambda;
+      (if Flambda_features.inlining_report ()
+      then
+        let output_prefix = prefixname ^ ".cps_conv" in
+        Inlining_report.output_then_forget_decisions ~output_prefix);
       if Flambda_features.classic_mode ()
       then { cmx = None; unit = flambda; all_code = code }
       else

--- a/middle_end/flambda2/flambda_middle_end.ml
+++ b/middle_end/flambda2/flambda_middle_end.ml
@@ -94,9 +94,10 @@ let middle_end0 ppf ~prefixname ~backend ~filename ~module_ident
           else flambda
         in
         let round = 0 in
+        let cmx_loader = Flambda_cmx.create_loader backend in
         let new_flambda =
           Profile.record_call ~accumulate:true "simplify" (fun () ->
-              Simplify.run ~backend ~round flambda)
+              Simplify.run ~backend ~cmx_loader ~round flambda)
         in
         (if Flambda_features.inlining_report ()
         then

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -168,6 +168,212 @@ let find_simple acc env (simple : IR.simple) =
 let find_simples acc env ids =
   List.fold_left_map (fun acc id -> find_simple acc env id) acc ids
 
+module Inlining = struct
+  type inlinable_result =
+    | Not_inlinable
+    | Inlinable of Env.function_description
+
+  let inlinable env name ~(inline_call: Inline_attribute.t) =
+    match Env.find_value_approximation env name with
+    | Value_unknown
+    | Block_approximation _ -> Not_inlinable
+    | Closure_approximation approx ->
+      let code = approx.fd_code in
+      let code_size =
+        Code.cost_metrics code
+        |> Cost_metrics.size |> Code_size.to_int
+      in
+      let inline : Inline_attribute.t =
+        match Code.inline code, inline_call with
+        | Never_inline, _ -> Never_inline
+        | inline_def, Default_inline -> inline_def
+        | _,_ -> inline_call
+      in
+      let threshold =
+        match inline with
+        | Default_inline ->
+          let inline_threshold =
+            Clflags.Float_arg_helper.get ~key:0 !Clflags.inline_threshold
+          in
+          (* CR keryan: should probably tweak this value *)
+          let magic_scale_constant = 3. in
+          int_of_float (inline_threshold *. magic_scale_constant)
+        | Always_inline | Hint_inline -> max_int
+        | Never_inline -> min_int
+        | Unroll _ -> assert false
+      in
+      if code_size <= threshold
+      (* && !Clflags.Flambda.Expert.fallback_inlining_heuristic *)
+      then Inlinable approx
+      else Not_inlinable
+
+  (* CR keryan: the remaining functions of the submodule are taken
+     from [Inlining_transforms] and adapted to local [Acc].
+     Some refactoring (functoring ?) is in order here. *)
+  let make_inlined_body acc ~callee ~params ~args ~my_closure ~my_depth ~body
+      ~free_names_of_body ~exn_continuation ~return_continuation
+      ~apply_exn_continuation ~apply_return_continuation ~apply_depth =
+    let perm = Renaming.empty in
+    let perm =
+      match (apply_return_continuation : Apply.Result_continuation.t) with
+      | Return k ->
+        Renaming.add_continuation perm return_continuation k
+      | Never_returns -> perm
+    in
+    let perm =
+      Renaming.add_continuation perm
+        (Exn_continuation.exn_handler exn_continuation)
+        apply_exn_continuation
+    in
+    let params = List.map Kinded_parameter.var params in
+    let acc =
+      Acc.with_free_names
+        (Name_occurrences.union (Acc.free_names acc) free_names_of_body)
+        acc
+    in
+    let acc, expr =
+      List.fold_left2 (fun (acc, body) param arg ->
+          Let_with_acc.create acc
+            (Bound_pattern.singleton (VB.create param Name_mode.normal))
+            (Named.create_simple arg) ~body
+          |> Expr_with_acc.create_let)
+        (acc, body) (my_closure::params) (callee::args)
+    in
+    let acc, expr =
+      let rec_info =
+        match apply_depth with
+        | None -> Rec_info_expr.initial
+        | Some depth -> Rec_info_expr.var depth
+      in
+      Let_with_acc.create acc
+        (Bound_pattern.singleton (VB.create my_depth Name_mode.normal))
+        (Named.create_rec_info rec_info) ~body:expr
+      |> Expr_with_acc.create_let
+    in
+    let acc =
+      Acc.with_free_names
+        (Name_occurrences.apply_renaming (Acc.free_names acc) perm)
+        acc
+    in
+    acc, Expr.apply_renaming expr perm
+
+  let wrap_inlined_body_for_exn_support acc ~extra_args ~apply_exn_continuation
+        ~apply_return_continuation ~result_arity ~make_inlined_body =
+    let wrapper = Continuation.create () in
+    let body_with_pop acc =
+      match (apply_return_continuation : Apply.Result_continuation.t) with
+      | Never_returns ->
+        make_inlined_body acc ~apply_exn_continuation:wrapper
+          ~apply_return_continuation
+      | Return apply_return_continuation ->
+        let pop_wrapper_cont = Continuation.create () in
+        let new_apply_return_continuation =
+          Apply.Result_continuation.Return pop_wrapper_cont
+        in
+        let body acc =
+          make_inlined_body acc ~apply_exn_continuation:wrapper
+            ~apply_return_continuation:new_apply_return_continuation
+        in
+        let kinded_params =
+          List.map (fun k -> Variable.create "wrapper_return", k)
+            result_arity
+        in
+        let trap_action =
+          Trap_action.Pop { exn_handler = wrapper; raise_kind = None; }
+        in
+        let args = List.map (fun (v, _) -> Simple.var v) kinded_params in
+        let handler acc =
+          let acc, apply_cont =
+            Apply_cont_with_acc.create acc
+              ~trap_action apply_return_continuation
+              ~args ~dbg:Debuginfo.none
+          in
+          Expr_with_acc.create_apply_cont acc apply_cont
+        in
+        Let_cont_with_acc.build_non_recursive acc pop_wrapper_cont
+          ~handler_params:(Kinded_parameter.List.create kinded_params)
+          ~handler ~body ~is_exn_handler:false
+    in
+    let param = Variable.create "exn" in
+    let wrapper_handler_params =
+      [Kinded_parameter.create
+         param K.With_subkind.any_value]
+    in
+    let exn_handler = Exn_continuation.exn_handler apply_exn_continuation in
+    let trap_action = Trap_action.Pop { exn_handler; raise_kind = None; } in
+    let wrapper_handler acc =
+      (* Backtrace building functions expect compiler-generated raises not to
+         have any debug info *)
+      let acc, apply_cont =
+        Apply_cont_with_acc.create acc ~trap_action
+          (Exn_continuation.exn_handler apply_exn_continuation)
+          ~args:((Simple.var param) :: (List.map fst extra_args))
+          ~dbg:Debuginfo.none
+        in
+        Expr_with_acc.create_apply_cont acc apply_cont
+    in
+    let body_with_push acc =
+      (* Wrap the body between push and pop of the wrapper handler *)
+      let push_wrapper_cont = Continuation.create () in
+      let push_wrapper_handler = body_with_pop in
+      let trap_action = Trap_action.Push { exn_handler = wrapper; } in
+      let body acc =
+        let acc, apply_cont =
+          Apply_cont_with_acc.create acc ~trap_action push_wrapper_cont ~args:[]
+            ~dbg:Debuginfo.none
+        in
+        Expr_with_acc.create_apply_cont acc apply_cont
+      in
+      Let_cont_with_acc.build_non_recursive acc push_wrapper_cont
+        ~handler_params:[] ~handler:push_wrapper_handler
+        ~body ~is_exn_handler:false
+    in
+    Let_cont_with_acc.build_non_recursive acc wrapper
+      ~handler_params:wrapper_handler_params ~handler:wrapper_handler
+      ~body:body_with_push ~is_exn_handler:true
+
+  let inline acc ~apply ~apply_depth ~func_desc:Env.{ fd_code; _ } =
+    let callee = Apply.callee apply in
+    let args = Apply.args apply in
+    let apply_return_continuation = Apply.continuation apply in
+    let apply_exn_continuation = Apply.exn_continuation apply in
+    let params_and_body =
+        Code.params_and_body_must_be_present
+          ~error_context:"Code needs params_and_body in [Closure_conversion]"
+          fd_code
+    in
+    Function_params_and_body.pattern_match params_and_body
+      ~f:(fun ~return_continuation exn_continuation params ~body ~my_closure
+           ~is_my_closure_used:_ ~my_depth ~free_names_of_body ->
+           if List.length args <> List.length params
+           then
+             Expr_with_acc.create_apply acc apply
+           else
+             let free_names_of_body =
+               match free_names_of_body with
+               | Unknown ->
+                 Misc.fatal_error "Params_and_body needs free_names_of_body \
+                                   in [Closure_conversion]"
+               | Known free_names -> free_names
+             in
+             let make_inlined_body =
+               make_inlined_body ~callee ~params ~args ~my_closure ~my_depth
+                 ~body ~free_names_of_body ~exn_continuation
+                 ~return_continuation ~apply_depth
+             in
+             let acc = Acc.with_free_names Name_occurrences.empty acc in
+             match Exn_continuation.extra_args apply_exn_continuation with
+             | [] ->
+               make_inlined_body acc ~apply_exn_continuation:
+                 (Exn_continuation.exn_handler apply_exn_continuation)
+                 ~apply_return_continuation
+             | extra_args ->
+               wrap_inlined_body_for_exn_support acc ~extra_args
+                 ~apply_exn_continuation ~apply_return_continuation
+                 ~result_arity:(Code.result_arity fd_code) ~make_inlined_body)
+end
+
+
 let close_c_call acc ~let_bound_var
     ({ prim_name;
        prim_arity;
@@ -471,17 +677,42 @@ let close_let acc env id user_visible defining_expr
     | Some (Simple simple) ->
       let body_env = Env.add_simple_to_substitute env id simple in
       body acc body_env
-    | Some _ | None -> (
+    | None ->
       (* CR pchambart: Not tail ! *)
       let acc, body = body acc body_env in
-      match defining_expr with
-      | None -> acc, body
-      | Some defining_expr ->
-        let var = VB.create var Name_mode.normal in
-        Let_with_acc.create acc
-          (Bound_pattern.singleton var)
-          defining_expr ~body
-        |> Expr_with_acc.create_let)
+      acc, body
+    | Some defining_expr ->
+      let body_env =
+        match defining_expr with
+        | Prim (Variadic (Make_block (_, Immutable), fields), _) ->
+          let approxs =
+            List.map (Env.find_value_approximation body_env) fields
+            |> Array.of_list
+          in
+          Env.add_block_approximation body_env (Name.var var) approxs
+        | Prim (Binary (Block_load _, block, field), _) ->
+          begin match Env.find_value_approximation body_env block with
+          | Value_unknown -> body_env
+          | Closure_approximation _ -> assert false
+          | Block_approximation approx ->
+            let approx : Env.value_approximation =
+              Simple.pattern_match field
+                ~const:(fun const ->
+                  match Reg_width_things.Const.descr const with
+                  | Tagged_immediate i ->
+                    approx.(Targetint_31_63.(Imm.to_int (to_targetint i)))
+                  | _ -> Env.Value_unknown)
+                ~name:(fun _ ~coercion:_ -> Env.Value_unknown)
+            in
+            Env.add_value_approximation body_env (Name.var var) approx
+          end
+        | _ -> body_env
+      in
+      let acc, body = body acc body_env in
+      let var = VB.create var Name_mode.normal in
+      Let_with_acc.create acc (Bound_pattern.singleton var) defining_expr
+        ~body
+      |> Expr_with_acc.create_let
   in
   close_named acc env ~let_bound_var:var defining_expr cont
 
@@ -504,6 +735,14 @@ let close_let_cont acc env ~name ~is_exn_handler ~params
       (List.map
          (fun (param, user_visible, _kind) -> param, user_visible)
          params)
+  in
+  let handler_env =
+    match Acc.continuation_known_arguments ~cont:name acc with
+    | None -> handler_env
+    | Some args ->
+      List.fold_left2 (fun env arg_approx param ->
+          Env.add_value_approximation env (Name.var param) arg_approx)
+        handler_env args params
   in
   let handler_params =
     List.map2
@@ -543,27 +782,39 @@ let close_apply acc env
       let acc, obj = find_simple acc env obj in
       acc, Call_kind.method_call (LC.method_kind kind) ~obj
   in
-  let acc, exn_continuation = close_exn_continuation acc env exn_continuation in
+  let acc, apply_exn_continuation =
+    close_exn_continuation acc env exn_continuation
+  in
   let callee = find_simple_from_id env func in
   let acc, args = find_simples acc env args in
+  let inline_call = LC.inline_attribute inlined in
   let probe_name =
     match probe with None -> None | Some { name } -> Some name
   in
   let apply =
-    Apply.create ~callee ~continuation:(Return continuation) exn_continuation
-      ~args ~call_kind
+    Apply.create ~callee
+      ~continuation:(Return continuation)
+      apply_exn_continuation
+      ~args
+      ~call_kind
       (Debuginfo.from_location loc)
-      ~inline:(LC.inline_attribute inlined)
+      ~inline:inline_call
       ~inlining_state:(Inlining_state.default ~round:0)
       ~probe_name
   in
-  Expr_with_acc.create_apply acc apply
+  match Inlining.inlinable env callee ~inline_call with
+  | Not_inlinable ->
+    Expr_with_acc.create_apply acc apply
+  | Inlinable func_desc ->
+    Inlining.inline acc ~apply ~apply_depth:(Env.current_depth env) ~func_desc
 
 let close_apply_cont acc env cont trap_action args : Acc.t * Expr_with_acc.t =
   let acc, args = find_simples acc env args in
   let trap_action = close_trap_action_opt trap_action in
+  let args_approx = List.map (Env.find_value_approximation env) args in
   let acc, apply_cont =
-    Apply_cont_with_acc.create acc ?trap_action cont ~args ~dbg:Debuginfo.none
+    Apply_cont_with_acc.create acc ?trap_action ~args_approx
+      cont ~args ~dbg:Debuginfo.none
   in
   Expr_with_acc.create_apply_cont acc apply_cont
 
@@ -738,8 +989,18 @@ let close_one_function acc ~external_env ~by_closure_id decl
   in
   let closure_env_without_parameters =
     let empty_env = Env.clear_local_bindings external_env in
-    let env = Env.add_var_map empty_env var_within_closures_for_idents in
-    Env.add_simple_to_substitute_map env simples_for_project_closure
+    let env_with_vars =
+      Ident.Map.fold (fun id var env ->
+          Simple.pattern_match (find_simple_from_id external_env id)
+            ~const:(fun _ -> assert false)
+            ~name:(fun name ~coercion:_ ->
+              Env.add_approximation_alias (Env.add_var env id var)
+                name (Name.var var))
+        )
+        var_within_closures_for_idents
+        empty_env
+    in
+    Env.add_simple_to_substitute_map env_with_vars simples_for_project_closure
   in
   let closure_env =
     List.fold_right
@@ -748,6 +1009,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
         env)
       params closure_env_without_parameters
   in
+  let closure_env = Env.with_depth closure_env my_depth in
   (* CR-someday pchambart: eta-expansion wrappers for primitives are not marked
      as stubs but certainly should be. *)
   let stub = Function_decl.stub decl in
@@ -866,9 +1128,20 @@ let close_one_function acc ~external_env ~by_closure_id decl
       ~inlining_arguments:(Inlining_arguments.create ~round:0)
       ~dbg ~is_tupled
   in
+  let description = Env.{
+    fd_code_id = code_id;
+    fd_code = code;
+    fd_ret_cont = return_continuation;
+    fd_exn_cont = exn_continuation;
+    fd_params = params;
+    fd_body = body;
+    fd_closure = my_closure;
+    fd_depth = my_depth;
+  }
+  in
   let acc = Acc.add_code ~code_id ~code acc in
   let acc = Acc.with_seen_a_function acc true in
-  acc, Closure_id.Map.add my_closure_id code_id by_closure_id
+  acc, Closure_id.Map.add my_closure_id description by_closure_id
 
 let close_functions acc external_env function_declarations =
   let compilation_unit = Compilation_unit.get_current_exn () in
@@ -926,7 +1199,15 @@ let close_functions acc external_env function_declarations =
   let acc = Acc.with_free_names Name_occurrences.empty acc in
   (* CR lmaurer: funs has arbitrary order (ultimately coming from
      function_declarations) *)
-  let funs = Closure_id.Lmap.of_list (Closure_id.Map.bindings funs) in
+  let funs, descriptions =
+    let funs, descs =
+      Closure_id.Map.fold (fun cid desc (funs, descs) ->
+          (cid, desc.Env.fd_code_id)::funs, desc::descs)
+        funs ([], [])
+    in
+    Closure_id.Lmap.of_list (List.rev funs),
+    List.rev descs
+  in
   let function_decls = Function_declarations.create funs in
   let closure_elements =
     Ident.Map.fold
@@ -938,7 +1219,9 @@ let close_functions acc external_env function_declarations =
         Var_within_closure.Map.add var_within_closure external_simple map)
       var_within_closures_from_idents Var_within_closure.Map.empty
   in
-  acc, Set_of_closures.create function_decls ~closure_elements
+  acc,
+  Set_of_closures.create function_decls ~closure_elements,
+  descriptions
 
 let close_let_rec acc env ~function_declarations
     ~(body : Acc.t -> Env.t -> Acc.t * Expr_with_acc.t) =
@@ -962,7 +1245,7 @@ let close_let_rec acc env ~function_declarations
         Closure_id.Map.add closure_id closure_var closure_vars)
       Closure_id.Map.empty function_declarations
   in
-  let acc, set_of_closures =
+  let acc, set_of_closures, approximations =
     close_functions acc env (Function_decls.create function_declarations)
   in
   (* CR mshinwell: We should maybe have something more elegant here *)
@@ -988,6 +1271,12 @@ let close_let_rec acc env ~function_declarations
       (Function_declarations.funs_in_order
          (Set_of_closures.function_decls set_of_closures)
       |> Closure_id.Lmap.bindings)
+  in
+  let env =
+    List.fold_left2 (fun env var approx ->
+      Env.add_closure_approximation env
+        (Name.var (VB.var var)) approx)
+      env closure_vars approximations
   in
   let acc, body = body acc env in
   let named = Named.create_set_of_closures set_of_closures in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -747,7 +747,11 @@ let close_let acc env id user_visible defining_expr
         | Prim (Binary (Block_load _, block, field), _) -> begin
           match Env.find_value_approximation body_env block with
           | Value_unknown -> body_env
-          | Closure_approximation _ -> assert false
+          | Closure_approximation _ ->
+            Misc.fatal_errorf
+              "Closure approximation found when block approximation was \
+               expected in [Closure_conversion]: %a"
+              Named.print defining_expr
           | Block_approximation approx ->
             let approx : Env.value_approximation =
               Simple.pattern_match field

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -753,14 +753,14 @@ let close_let acc env id user_visible defining_expr
                expected in [Closure_conversion]: %a"
               Named.print defining_expr
           | Block_approximation approx ->
-            let approx : Env.value_approximation =
+            let approx : Value_approximation.t =
               Simple.pattern_match field
                 ~const:(fun const ->
                   match Reg_width_things.Const.descr const with
                   | Tagged_immediate i ->
                     approx.(Targetint_31_63.(Imm.to_int (to_targetint i)))
-                  | _ -> Env.Value_unknown)
-                ~name:(fun _ ~coercion:_ -> Env.Value_unknown)
+                  | _ -> Value_approximation.Value_unknown)
+                ~name:(fun _ ~coercion:_ -> Value_approximation.Value_unknown)
             in
             Env.add_value_approximation body_env (Name.var var) approx
         end

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -66,9 +66,10 @@ val close_switch :
 
 val close_program :
   backend:(module Flambda_backend_intf.S) ->
+  cmx_loader:Flambda_cmx.loader ->
   module_ident:Ident.t ->
   module_block_size_in_words:int ->
   program:(Acc.t -> Env.t -> Acc.t * Expr_with_acc.t) ->
   prog_return_cont:Continuation.t ->
   exn_continuation:Continuation.t ->
-  Flambda_unit.t * Exported_code.t
+  Flambda_unit.t * Exported_code.t * Flambda_cmx_format.t

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -89,19 +89,37 @@ module IR = struct
 end
 
 module Env = struct
-  type t =
-    { variables : Variable.t Ident.Map.t;
-      globals : Symbol.t Numeric_types.Int.Map.t;
-      simples_to_substitute : Simple.t Ident.Map.t;
-      backend : (module Flambda_backend_intf.S);
-      current_unit_id : Ident.t;
-      symbol_for_global' : Ident.t -> Symbol.t
-    }
+  type function_description = {
+    fd_code_id : Code_id.t;
+    fd_code : Flambda.Code.t;
+    fd_ret_cont : Continuation.t;
+    fd_exn_cont : Exn_continuation.t;
+    fd_params : Kinded_parameter.t list;
+    fd_body : Flambda.Expr.t;
+    fd_closure : Variable.t;
+    fd_depth : Variable.t;
+  }
+
+  type value_approximation =
+    | Value_unknown
+    | Closure_approximation of function_description
+    | Block_approximation of value_approximation array
+
+  type t = {
+    variables : Variable.t Ident.Map.t;
+    globals : Symbol.t Numeric_types.Int.Map.t;
+    simples_to_substitute : Simple.t Ident.Map.t;
+    backend : (module Flambda_backend_intf.S);
+    current_unit_id : Ident.t;
+    current_depth : Variable.t option;
+    symbol_for_global' : (Ident.t -> Symbol.t);
+    value_approximations : value_approximation Name.Map.t;
+  }
 
   let backend t = t.backend
 
   let current_unit_id t = t.current_unit_id
-
+  let current_depth t = t.current_depth
   let symbol_for_global' t = t.symbol_for_global'
 
   let empty ~backend =
@@ -112,17 +130,15 @@ module Env = struct
       simples_to_substitute = Ident.Map.empty;
       backend;
       current_unit_id = Compilation_unit.get_persistent_ident compilation_unit;
-      symbol_for_global' = Backend.symbol_for_global'
+      current_depth = None;
+      symbol_for_global' = Backend.symbol_for_global';
+      value_approximations = Name.Map.empty;
     }
 
   let clear_local_bindings
-      { variables = _;
-        globals;
-        simples_to_substitute;
-        backend;
-        current_unit_id;
-        symbol_for_global'
-      } =
+        { variables = _; globals; simples_to_substitute; backend;
+          current_unit_id; current_depth; symbol_for_global';
+          value_approximations } =
     let simples_to_substitute =
       Ident.Map.filter
         (fun _ simple -> not (Simple.is_var simple))
@@ -133,8 +149,12 @@ module Env = struct
       simples_to_substitute;
       backend;
       current_unit_id;
-      symbol_for_global'
+      current_depth;
+      symbol_for_global';
+      value_approximations;
     }
+
+  let with_depth t depth_var = { t with current_depth = Some depth_var; }
 
   let add_var t id var = { t with variables = Ident.Map.add id var t.variables }
 
@@ -209,17 +229,49 @@ module Env = struct
 
   let find_simple_to_substitute_exn t id =
     Ident.Map.find id t.simples_to_substitute
+
+  let add_value_approximation t name approx =
+    if approx = Value_unknown then t
+    else
+      { t with value_approximations =
+        Name.Map.add name approx t.value_approximations;
+      }
+
+  let add_closure_approximation t name approx =
+    add_value_approximation t name (Closure_approximation approx)
+
+  let add_block_approximation t name approxs =
+    if Array.for_all ((=) Value_unknown) approxs then t
+    else
+      add_value_approximation t name (Block_approximation approxs)
+
+  let find_value_approximation t simple =
+    Simple.pattern_match simple
+      ~const:(fun _ -> Value_unknown)
+      ~name:(fun name ~coercion:_ ->
+          try Name.Map.find name t.value_approximations with
+          | Not_found -> Value_unknown)
+
+  let add_approximation_alias t name alias =
+    match find_value_approximation t (Simple.name name) with
+    | Value_unknown -> t
+    | approx -> add_value_approximation t alias approx
 end
 
 module Acc = struct
-  type t =
-    { declared_symbols : (Symbol.t * Flambda.Static_const.t) list;
-      shareable_constants : Symbol.t Flambda.Static_const.Map.t;
-      code : Flambda.Code.t Code_id.Map.t;
-      free_names : Name_occurrences.t;
-      cost_metrics : Flambda.Cost_metrics.t;
-      seen_a_function : bool
-    }
+  type continuation_application =
+    | Trackable_arguments of Env.value_approximation list
+    | Untrackable
+
+  type t = {
+    declared_symbols : (Symbol.t * Flambda.Static_const.t) list;
+    shareable_constants : Symbol.t Flambda.Static_const.Map.t;
+    code : Flambda.Code.t Code_id.Map.t;
+    free_names : Name_occurrences.t;
+    continuation_applications : continuation_application Continuation.Map.t;
+    cost_metrics : Flambda.Cost_metrics.t;
+    seen_a_function : bool;
+  }
 
   let cost_metrics t = t.cost_metrics
 
@@ -229,17 +281,18 @@ module Acc = struct
   let with_cost_metrics cost_metrics t = { t with cost_metrics }
 
   let seen_a_function t = t.seen_a_function
+  let with_seen_a_function t seen_a_function =
+    { t with seen_a_function; }
 
-  let with_seen_a_function t seen_a_function = { t with seen_a_function }
-
-  let empty =
-    { declared_symbols = [];
-      shareable_constants = Flambda.Static_const.Map.empty;
-      code = Code_id.Map.empty;
-      free_names = Name_occurrences.empty;
-      cost_metrics = Flambda.Cost_metrics.zero;
-      seen_a_function = false
-    }
+  let empty = {
+    declared_symbols = [];
+    shareable_constants = Flambda.Static_const.Map.empty;
+    code = Code_id.Map.empty;
+    free_names = Name_occurrences.empty;
+    continuation_applications = Continuation.Map.empty;
+    cost_metrics = Flambda.Cost_metrics.zero;
+    seen_a_function = false;
+  }
 
   let declared_symbols t = t.declared_symbols
 
@@ -286,15 +339,40 @@ module Acc = struct
   let remove_var_from_free_names var t =
     { t with free_names = Name_occurrences.remove_var t.free_names var }
 
+  let add_continuation_application ~cont args_approx t =
+    let continuation_application =
+      match args_approx with
+      | None -> Untrackable
+      | Some args ->
+        if Continuation.Map.mem cont t.continuation_applications
+        then Untrackable
+        else Trackable_arguments args
+    in
+    { t with
+      continuation_applications =
+        Continuation.Map.add cont continuation_application
+          t.continuation_applications;
+    }
+
   let remove_continuation_from_free_names cont t =
     { t with
-      free_names = Name_occurrences.remove_continuation t.free_names cont
+      free_names =
+        Name_occurrences.remove_continuation t.free_names cont;
+      continuation_applications =
+        Continuation.Map.remove cont t.continuation_applications;
     }
 
   let remove_code_id_from_free_names code_id t =
     remove_code_id_or_symbol_from_free_names (Code_id code_id) t
 
-  let with_free_names free_names t = { t with free_names }
+  let continuation_known_arguments ~cont t =
+    match Continuation.Map.find cont t.continuation_applications with
+    | exception Not_found
+    | Untrackable -> None
+    | Trackable_arguments args -> Some args
+
+  let with_free_names free_names t =
+    { t with free_names; }
 
   let eval_branch_free_names t ~f =
     let base_free_names = t.free_names in
@@ -477,12 +555,16 @@ module Expr_with_acc = struct
 end
 
 module Apply_cont_with_acc = struct
-  let create acc ?trap_action cont ~args ~dbg =
-    let apply_cont = Apply_cont.create ?trap_action cont ~args ~dbg in
+  let create acc ?trap_action ?args_approx cont ~args ~dbg =
+    let apply_cont =
+      Apply_cont.create ?trap_action cont ~args ~dbg
+    in
+    let acc = Acc.add_continuation_application ~cont args_approx acc in
     let acc = Acc.add_free_names (Apply_cont.free_names apply_cont) acc in
     acc, apply_cont
 
-  let goto acc cont = create acc cont ~args:[] ~dbg:Debuginfo.none
+  let goto acc cont =
+    create acc cont ~args:[] ?args_approx:None ~dbg:(Debuginfo.none)
 end
 
 module Let_with_acc = struct

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -89,19 +89,9 @@ module IR = struct
 end
 
 module Env = struct
-  type function_description =
-    { fd_code : Flambda.Code.t;
-      fd_ret_cont : Continuation.t;
-      fd_exn_cont : Exn_continuation.t;
-      fd_params : Kinded_parameter.t list;
-      fd_body : Flambda.Expr.t;
-      fd_closure : Variable.t;
-      fd_depth : Variable.t
-    }
-
   type value_approximation =
     | Value_unknown
-    | Closure_approximation of Code_id.t * function_description option
+    | Closure_approximation of Code_id.t * Flambda.Code.t option
     | Block_approximation of value_approximation array
 
   type t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -123,17 +123,11 @@ module Env = struct
            Value_approximation.Value_unknown
          | Some typing_env ->
            (* Format.eprintf "Loaded %a" Compilation_unit.print comp_unit; *)
-           let approxs =
-             Flambda_type.Typing_env.to_closure_conversion_approx typing_env
-               ~get_imported_code:(Flambda_cmx.get_imported_code loader)
+           let approx =
+             Flambda_type.Typing_env.to_closure_conversion_approx typing_env symbol
            in
-           externals :=
-             Symbol.Map.union
-               (fun s _ _ ->
-                  Misc.fatal_errorf "External symbol %a loaded twice."
-                    Symbol.print s)
-               approxs !externals;
-           Symbol.Map.find symbol approxs)
+           externals := Symbol.Map.add symbol approx !externals;
+           approx)
 
   let empty ~backend ~cmx_loader =
     let module Backend = (val backend : Flambda_backend_intf.S) in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -79,11 +79,6 @@ end
     values during closure conversion, and similarly for static exception
     identifiers. *)
 module Env : sig
-  type value_approximation =
-    | Value_unknown
-    | Closure_approximation of Code_id.t * Flambda.Code.t option
-    | Block_approximation of value_approximation array
-
   type t
 
   val empty : backend:(module Flambda_backend_intf.S) -> t
@@ -121,16 +116,16 @@ module Env : sig
 
   val find_simple_to_substitute_exn : t -> Ident.t -> Simple.t
 
-  val add_value_approximation : t -> Name.t -> value_approximation -> t
+  val add_value_approximation : t -> Name.t -> Value_approximation.t -> t
 
   val add_closure_approximation :
     t -> Name.t -> Code_id.t * Flambda.Code.t option -> t
 
-  val add_block_approximation : t -> Name.t -> value_approximation array -> t
+  val add_block_approximation : t -> Name.t -> Value_approximation.t array -> t
 
   val add_approximation_alias : t -> Name.t -> Name.t -> t
 
-  val find_value_approximation : t -> Simple.t -> value_approximation
+  val find_value_approximation : t -> Simple.t -> Value_approximation.t
 
   val current_depth : t -> Variable.t option
 
@@ -176,7 +171,7 @@ module Acc : sig
   val remove_continuation_from_free_names : Continuation.t -> t -> t
 
   val continuation_known_arguments :
-    cont:Continuation.t -> t -> Env.value_approximation list option
+    cont:Continuation.t -> t -> Value_approximation.t list option
 
   val with_free_names : Name_occurrences.t -> t -> t
 
@@ -286,7 +281,7 @@ module Apply_cont_with_acc : sig
   val create :
     Acc.t ->
     ?trap_action:Trap_action.t ->
-    ?args_approx:Env.value_approximation list ->
+    ?args_approx:Value_approximation.t list ->
     Continuation.t ->
     args:Simple.t list ->
     dbg:Debuginfo.t ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -79,19 +79,9 @@ end
     values during closure conversion, and similarly for static exception
     identifiers. *)
 module Env : sig
-  type function_description =
-    { fd_code : Flambda.Code.t;
-      fd_ret_cont : Continuation.t;
-      fd_exn_cont : Exn_continuation.t;
-      fd_params : Kinded_parameter.t list;
-      fd_body : Flambda.Expr.t;
-      fd_closure : Variable.t;
-      fd_depth : Variable.t
-    }
-
   type value_approximation =
     | Value_unknown
-    | Closure_approximation of Code_id.t * function_description option
+    | Closure_approximation of Code_id.t * Flambda.Code.t option
     | Block_approximation of value_approximation array
 
   type t
@@ -134,7 +124,7 @@ module Env : sig
   val add_value_approximation : t -> Name.t -> value_approximation -> t
 
   val add_closure_approximation :
-    t -> Name.t -> Code_id.t * function_description option -> t
+    t -> Name.t -> Code_id.t * Flambda.Code.t option -> t
 
   val add_block_approximation : t -> Name.t -> value_approximation array -> t
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -81,7 +81,9 @@ end
 module Env : sig
   type t
 
-  val empty : backend:(module Flambda_backend_intf.S) -> t
+  val empty :
+    backend:(module Flambda_backend_intf.S)
+    -> cmx_loader:Flambda_cmx.loader -> t
 
   val clear_local_bindings : t -> t
 
@@ -136,6 +138,7 @@ module Env : sig
   val current_unit_id : t -> Ident.t
 
   val symbol_for_global' : t -> Ident.t -> Symbol.t
+
 end
 
 (** Used to pipe some data through closure conversion *)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -79,6 +79,22 @@ end
     values during closure conversion, and similarly for static exception
     identifiers. *)
 module Env : sig
+  type function_description = {
+    fd_code_id : Code_id.t;
+    fd_code : Flambda.Code.t;
+    fd_ret_cont : Continuation.t;
+    fd_exn_cont : Exn_continuation.t;
+    fd_params : Kinded_parameter.t list;
+    fd_body : Flambda.Expr.t;
+    fd_closure : Variable.t;
+    fd_depth : Variable.t;
+  }
+
+  type value_approximation =
+    | Value_unknown
+    | Closure_approximation of function_description
+    | Block_approximation of value_approximation array
+
   type t
 
   val empty : backend:(module Flambda_backend_intf.S) -> t
@@ -115,6 +131,15 @@ module Env : sig
   val add_simple_to_substitute_map : t -> Simple.t Ident.Map.t -> t
 
   val find_simple_to_substitute_exn : t -> Ident.t -> Simple.t
+
+  val add_value_approximation : t -> Name.t -> value_approximation -> t
+  val add_closure_approximation : t -> Name.t -> function_description -> t
+  val add_block_approximation : t -> Name.t -> value_approximation array -> t
+  val add_approximation_alias : t -> Name.t -> Name.t -> t
+  val find_value_approximation : t -> Simple.t -> value_approximation
+
+  val current_depth : t -> Variable.t option
+  val with_depth : t -> Variable.t -> t
 
   val backend : t -> (module Flambda_backend_intf.S)
 
@@ -154,6 +179,9 @@ module Acc : sig
   val remove_var_from_free_names : Variable.t -> t -> t
 
   val remove_continuation_from_free_names : Continuation.t -> t -> t
+
+  val continuation_known_arguments
+    : cont:Continuation.t -> t -> Env.value_approximation list option
 
   val with_free_names : Name_occurrences.t -> t -> t
 
@@ -260,15 +288,19 @@ module Expr_with_acc : sig
 end
 
 module Apply_cont_with_acc : sig
-  val create :
-    Acc.t ->
-    ?trap_action:Trap_action.t ->
-    Continuation.t ->
-    args:Simple.t list ->
-    dbg:Debuginfo.t ->
-    Acc.t * Apply_cont.t
+  val create
+     : Acc.t
+    -> ?trap_action:Trap_action.t
+    -> ?args_approx:Env.value_approximation list
+    -> Continuation.t
+    -> args:Simple.t list
+    -> dbg:Debuginfo.t
+    -> Acc.t * Apply_cont.t
 
-  val goto : Acc.t -> Continuation.t -> Acc.t * Apply_cont.t
+  val goto
+     : Acc.t
+    -> Continuation.t
+    -> Acc.t * Apply_cont.t
 end
 
 module Let_with_acc : sig

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1535,8 +1535,9 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~scrutinee
       switch_expr acc ccenv)
     k_exn
 
-let lambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
-    (lam : Lambda.lambda) : Flambda_unit.t * Exported_code.t =
+let lambda_to_flambda ~backend ~cmx_loader ~module_ident
+    ~module_block_size_in_words (lam : Lambda.lambda)
+  : Flambda_unit.t * Exported_code.t * Flambda_cmx_format.t =
   let current_unit_id =
     Compilation_unit.get_persistent_ident (Compilation_unit.get_current_exn ())
   in
@@ -1548,5 +1549,6 @@ let lambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
   let toplevel acc ccenv =
     cps_tail acc env ccenv lam return_continuation exn_continuation
   in
-  CC.close_program ~backend ~module_ident ~module_block_size_in_words
-    ~program:toplevel ~prog_return_cont:return_continuation ~exn_continuation
+  CC.close_program ~backend ~cmx_loader ~module_ident
+    ~module_block_size_in_words ~program:toplevel
+    ~prog_return_cont:return_continuation ~exn_continuation

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
@@ -20,7 +20,8 @@
 
 val lambda_to_flambda :
   backend:(module Flambda_backend_intf.S) ->
+  cmx_loader:Flambda_cmx.loader ->
   module_ident:Ident.t ->
   module_block_size_in_words:int ->
   Lambda.lambda ->
-  Flambda_unit.t * Exported_code.t
+  Flambda_unit.t * Exported_code.t * Flambda_cmx_format.t

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -731,6 +731,7 @@ and static_let_expr env bound_symbols defining_expr body : Fexpr.expr =
                    ~my_closure
                    ~is_my_closure_used:_
                    ~my_depth
+                   ~free_names_of_body:_
                    :
                    Fexpr.params_and_body
                  ->

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
@@ -21,7 +21,7 @@ open! Flambda.Import
 (* CR-someday mshinwell: Maybe have two types, one giving the reasons why
    something can be inlined, and one giving the reasons why something cannot be
    inlined. *)
-type t = private
+type t =
   | Environment_says_never_inline
   | Unrolling_depth_exceeded
   | Max_inlining_depth_exceeded

--- a/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.mli
+++ b/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.mli
@@ -18,7 +18,7 @@
 
 open! Flambda.Import
 
-type t = private
+type t =
   | Never_inline_attribute
   | Function_body_too_large of Code_size.t
   | Stub

--- a/middle_end/flambda2/simplify/inlining/inlining_report.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_report.ml
@@ -26,6 +26,7 @@ type at_call_site =
       }
 
 type fundecl_pass =
+  | After_closure_conversion
   | Before_simplify
   | After_simplify
 
@@ -84,6 +85,16 @@ let [@ocamlformat "disable"] rec print ~depth fmt = function
   | [] ->
     if depth <> 0 then
       Misc.fatal_errorf "incoherent depth at end of inlining report"
+
+  (* After closure conversion of a function *)
+  | { dbg; decision = At_function_declaration {
+      pass = After_closure_conversion; code_id; decision; } } :: r ->
+    Format.fprintf fmt "%a Definition of %s{%a}@\n"
+      stars depth Code_id.(name (import code_id)) print_debuginfo dbg;
+    Format.fprintf fmt "%a @[<v>After closure conversion:@ @ %a@]@\n@\n"
+      stars (depth + 1)
+      Function_decl_inlining_decision.report decision;
+    print ~depth fmt r
 
   (* Entering a function declaration (possibly nested) *)
   | { dbg; decision = At_function_declaration {

--- a/middle_end/flambda2/simplify/inlining/inlining_report.mli
+++ b/middle_end/flambda2/simplify/inlining/inlining_report.mli
@@ -31,9 +31,12 @@ type at_call_site =
     simplifying the body, and one after (this is useful for e.g. recursive
     functions). *)
 type fundecl_pass =
+  | After_closure_conversion
   | Before_simplify
   | After_simplify
-(**)
+      (** There are three decisions made for each function declaration: on after
+          conversion in CPS and closure, one before simplifying the body, and
+          one after (this is useful for e.g. recursive functions). *)
 
 type at_function_declaration =
   { pass : fundecl_pass;
@@ -44,6 +47,7 @@ type at_function_declaration =
 (** This defines the various kinds of decisions related to inlining that will be
     reported, together with some additional information to better identify to
     what the decision refers to. *)
+
 type decision =
   | At_call_site of at_call_site
   | At_function_declaration of at_function_declaration

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -214,6 +214,7 @@ let inline dacc ~apply ~unroll_to function_decl =
          ~my_closure
          ~is_my_closure_used:_
          ~my_depth
+         ~free_names_of_body:_
        ->
       let make_inlined_body =
         make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~my_depth

--- a/middle_end/flambda2/simplify/non_constructed_code.ml
+++ b/middle_end/flambda2/simplify/non_constructed_code.ml
@@ -21,8 +21,6 @@ include
     (struct
       include Unit
 
-      let free_names_of_body _ = Or_unknown.Unknown
-
       let all_ids_for_export _ = Ids_for_export.empty
     end)
     (Flambda.Cost_metrics)

--- a/middle_end/flambda2/simplify/simplify.mli
+++ b/middle_end/flambda2/simplify/simplify.mli
@@ -30,6 +30,7 @@ type simplify_result = private
 
 val run :
   backend:(module Flambda_backend_intf.S) ->
+  cmx_loader:Flambda_cmx.loader ->
   round:int ->
   Flambda_unit.t ->
   simplify_result

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -459,6 +459,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants closure_id
            ~my_closure
            ~is_my_closure_used:_
            ~my_depth
+           ~free_names_of_body:_
          ->
         let dacc =
           dacc_inside_function context ~used_closure_vars ~shareable_constants

--- a/middle_end/flambda2/terms/code0.ml
+++ b/middle_end/flambda2/terms/code0.ml
@@ -26,8 +26,6 @@ module Make (Function_params_and_body : sig
 
   val apply_renaming : t -> Renaming.t -> t
 
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
-
   val print : Format.formatter -> t -> unit
 end) (Cost_metrics : sig
   type t
@@ -265,13 +263,6 @@ struct
           older Name_mode.normal
     in
     Name_occurrences.union from_newer_version_of t.free_names_of_params_and_body
-
-  let free_names_of_body t =
-    let params_and_body =
-      params_and_body_must_be_present
-        ~error_context:"Accessing free_names_of_body" t
-    in
-    Function_params_and_body.free_names_of_body params_and_body
 
   let apply_renaming
       ({ code_id;

--- a/middle_end/flambda2/terms/code0.mli
+++ b/middle_end/flambda2/terms/code0.mli
@@ -23,8 +23,6 @@ module Make (Function_params_and_body : sig
 
   val apply_renaming : t -> Renaming.t -> t
 
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
-
   val print : Format.formatter -> t -> unit
 end) (Cost_metrics : sig
   type t

--- a/middle_end/flambda2/terms/code_intf.ml
+++ b/middle_end/flambda2/terms/code_intf.ml
@@ -90,8 +90,6 @@ module type S = sig
 
   include Contains_names.S with type t := t
 
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
-
   val print : Format.formatter -> t -> unit
 
   val all_ids_for_export : t -> Ids_for_export.t

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -434,6 +434,7 @@ and Function_params_and_body : sig
       my_closure:Variable.t ->
       is_my_closure_used:bool Or_unknown.t ->
       my_depth:Variable.t ->
+      free_names_of_body:Name_occurrences.t Or_unknown.t ->
       'a) ->
     'a
 
@@ -459,8 +460,6 @@ and Function_params_and_body : sig
       my_depth:Variable.t ->
       'a) ->
     'a
-
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
 
   (** Return the debuginfo associated *)
   val debuginfo : t -> Debuginfo.t
@@ -638,8 +637,6 @@ and Code : sig
   val print : Format.formatter -> t -> unit
 
   include Contains_names.S with type t := t
-
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
 
   val all_ids_for_export : t -> Ids_for_export.t
 

--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -206,6 +206,7 @@ module Iter = struct
                  ~my_closure:_
                  ~is_my_closure_used:_
                  ~my_depth:_
+                 ~free_names_of_body:_
                -> expr f_c f_s body))
       ~set_of_closures:(fun () ~closure_symbols set_of_closures ->
         f_s ~closure_symbols:(Some closure_symbols) ~is_phantom:false

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -1459,6 +1459,7 @@ and params_and_body env res fun_name p =
          ~my_closure
          ~is_my_closure_used
          ~my_depth:_
+         ~free_names_of_body:_
        ->
       try
         let args = function_args vars my_closure ~is_my_closure_used in

--- a/middle_end/flambda2/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env.rec.ml
@@ -542,7 +542,7 @@ let to_closure_conversion_approx
   let names_to_types = Cached.names_to_types just_after_level in
   let get_symbol_type sym =
     match Name.Map.find_opt (Name.symbol sym) names_to_types with
-    | None -> Misc.fatal_errorf "No equation for symbol %a" Symbol.print sym
+    | None -> Type_grammar.unknown Flambda_kind.value
     | Some (ty, _, _) -> ty
   in
   Symbol.Set.fold

--- a/middle_end/flambda2/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env.rec.ml
@@ -475,15 +475,15 @@ end
 let to_closure_conversion_approx
     ({ resolver = _;
        get_imported_names = _;
-       get_imported_code = _;
-       defined_symbols;
+       get_imported_code;
+       defined_symbols = _;
        code_age_relation = _;
        all_code = _;
        prev_levels = _;
        current_level;
        next_binding_time = _;
        min_binding_time = _
-     } as typing_env) ~get_imported_code =
+     } as typing_env) symbol =
   let just_after_level = One_level.just_after_level current_level in
   let all_code = get_imported_code () in
   let rec type_to_approx (ty : Type_grammar.t) : Value_approximation.t =
@@ -541,16 +541,12 @@ let to_closure_conversion_approx
     end
   in
   let names_to_types = Cached.names_to_types just_after_level in
-  let get_symbol_type sym =
-    match Name.Map.find_opt (Name.symbol sym) names_to_types with
+  let symbol_type =
+    match Name.Map.find_opt (Name.symbol symbol) names_to_types with
     | None -> Type_grammar.unknown Flambda_kind.value
     | Some (ty, _, _) -> ty
   in
-  Symbol.Set.fold
-    (fun sym approxs ->
-      let approx = type_to_approx (get_symbol_type sym) in
-      Symbol.Map.add sym approx approxs)
-    defined_symbols Symbol.Map.empty
+  type_to_approx symbol_type
 
 let is_empty t =
   One_level.is_empty t.current_level

--- a/middle_end/flambda2/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env.rec.ml
@@ -259,6 +259,17 @@ module Serializable : sig
 
   val create : typing_env -> t
 
+  val create_from_closure_conversion_approx :
+    Value_approximation.t Symbol.Map.t -> t
+
+  val to_closure_conversion_approx :
+    t ->
+    Flambda.Code.t Code_id.Map.t ->
+    resolver:(Compilation_unit.t -> typing_env option) ->
+    get_imported_names:(unit -> Name.Set.t) ->
+    get_imported_code:(unit -> Exported_code.t) ->
+    Value_approximation.t Symbol.Map.t
+
   val print : Format.formatter -> t -> unit
 
   val to_typing_env :
@@ -303,6 +314,52 @@ end = struct
       next_binding_time
     }
 
+  let create_from_closure_conversion_approx
+      (symbols : Value_approximation.t Symbol.Map.t) =
+    let defined_symbols = Symbol.Map.keys symbols in
+    let code_age_relation = Code_age_relation.empty in
+    let next_binding_time = Binding_time.earliest_var in
+    let rec type_from_approx approx =
+      match (approx : Value_approximation.t) with
+      | Value_unknown -> Type_grammar.unknown Flambda_kind.value
+      | Block_approximation fields ->
+        let fields = List.map type_from_approx (Array.to_list fields) in
+        Type_grammar.immutable_block ~is_unique:false Tag.zero
+          ~field_kind:Flambda_kind.value ~fields
+      | Closure_approximation (code_id, code_opt) ->
+        let closure_id =
+          Closure_id.wrap
+            (Compilation_unit.get_current_exn ())
+            (Variable.create (Code_id.name code_id))
+        in
+        let fun_decl =
+          match code_opt with
+          | Some _ ->
+            Type_grammar.create_inlinable_function_declaration ~code_id
+              ~rec_info:(Type_grammar.unknown Flambda_kind.rec_info)
+          | None ->
+            Type_grammar.create_non_inlinable_function_declaration ~code_id
+        in
+        let all_function_decls_in_set =
+          Closure_id.Map.singleton closure_id fun_decl
+        in
+        let all_closures_in_set =
+          Closure_id.Map.singleton closure_id
+            (Type_grammar.unknown Flambda_kind.value)
+        in
+        let all_closure_vars_in_set = Var_within_closure.Map.empty in
+        Type_grammar.exactly_this_closure closure_id ~all_function_decls_in_set
+          ~all_closures_in_set ~all_closure_vars_in_set
+    in
+    let just_after_level =
+      Symbol.Map.fold
+        (fun sym approx cached ->
+          Cached.add_or_replace_binding cached (Name.symbol sym)
+            (type_from_approx approx) Binding_time.symbols Name_mode.normal)
+        symbols Cached.empty
+    in
+    { defined_symbols; code_age_relation; just_after_level; next_binding_time }
+
   let [@ocamlformat "disable"] print ppf { defined_symbols;
                   code_age_relation;
                   just_after_level;
@@ -346,6 +403,82 @@ end = struct
          [get_imported_code] callback, so [all_code] is left empty here. *)
       all_code = Code_id.Map.empty
     }
+
+  let to_closure_conversion_approx
+      ({ defined_symbols;
+         code_age_relation = _;
+         just_after_level;
+         next_binding_time = _
+       } as t) all_code ~resolver ~get_imported_names ~get_imported_code =
+    let typing_env =
+      to_typing_env t ~resolver ~get_imported_names ~get_imported_code
+    in
+    let rec type_to_approx (ty : Type_grammar.t) : Value_approximation.t =
+      let resolved = Type_grammar.expand_head ty typing_env in
+      match resolved with
+      | Const _ -> Value_unknown
+      | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+      | Naked_nativeint _ | Rec_info _ ->
+        Misc.fatal_error
+          "Typing_env.Serializable.to_closure_conversion_approx: Wrong kind"
+      | Value (Unknown | Bottom) -> Value_unknown
+      | Value (Ok ty) -> begin
+        match ty with
+        | Array _ | String _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+        | Boxed_nativeint _ ->
+          Value_unknown
+        | Closures { by_closure_id } -> (
+          let module RLC =
+            Row_like.For_closures_entry_by_set_of_closures_contents
+          in
+          match RLC.get_singleton by_closure_id with
+          | None -> Value_unknown
+          | Some ((closure_id, _contents), closures_entry) -> begin
+            match
+              Closures_entry.find_function_declaration closures_entry closure_id
+            with
+            | Bottom | Ok Bottom | Ok Unknown -> Value_unknown
+            | Ok (Ok (Inlinable inlinable)) ->
+              let code_id =
+                Function_declaration_type.Inlinable.code_id inlinable
+              in
+              let code = Code_id.Map.find_opt code_id all_code in
+              (* CR vlaviron: Should we fail if [code] is [None] ? *)
+              Closure_approximation (code_id, code)
+            | Ok (Ok (Non_inlinable non_inlinable)) ->
+              let code_id =
+                Function_declaration_type.Non_inlinable.code_id non_inlinable
+              in
+              Closure_approximation (code_id, None)
+          end)
+        | Variant { immediates = Unknown; blocks = _; is_unique = _ }
+        | Variant { immediates = _; blocks = Unknown; is_unique = _ } ->
+          Value_unknown
+        | Variant
+            { immediates = Known imms; blocks = Known blocks; is_unique = _ } ->
+          if Type_grammar.is_obviously_bottom imms
+          then
+            match Row_like.For_blocks.get_singleton blocks with
+            | None -> Value_unknown
+            | Some ((_tag, _size), fields) ->
+              let fields =
+                List.map type_to_approx (Product.Int_indexed.components fields)
+              in
+              Block_approximation (Array.of_list fields)
+          else Value_unknown
+      end
+    in
+    let names_to_types = Cached.names_to_types just_after_level in
+    let get_symbol_type sym =
+      match Name.Map.find_opt (Name.symbol sym) names_to_types with
+      | None -> Misc.fatal_errorf "No equation for symbol %a" Symbol.print sym
+      | Some (ty, _, _) -> ty
+    in
+    Symbol.Set.fold
+      (fun sym approxs ->
+        let approx = type_to_approx (get_symbol_type sym) in
+        Symbol.Map.add sym approx approxs)
+      defined_symbols Symbol.Map.empty
 
   (* CR mshinwell for vlaviron: Shouldn't some of this be in
      [Cached.all_ids_for_export]? *)

--- a/middle_end/flambda2/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env.rec.ml
@@ -478,13 +478,14 @@ let to_closure_conversion_approx
        get_imported_code = _;
        defined_symbols;
        code_age_relation = _;
-       all_code;
+       all_code = _;
        prev_levels = _;
        current_level;
        next_binding_time = _;
        min_binding_time = _
-     } as typing_env) =
+     } as typing_env) ~get_imported_code =
   let just_after_level = One_level.just_after_level current_level in
+  let all_code = get_imported_code () in
   let rec type_to_approx (ty : Type_grammar.t) : Value_approximation.t =
     let resolved = Type_grammar.expand_head ty typing_env in
     match resolved with
@@ -513,7 +514,7 @@ let to_closure_conversion_approx
             let code_id =
               Function_declaration_type.Inlinable.code_id inlinable
             in
-            let code = Code_id.Map.find_opt code_id all_code in
+            let code = Exported_code.find_code all_code code_id in
             (* CR vlaviron: Should we fail if [code] is [None] ? *)
             Closure_approximation (code_id, code)
           | Ok (Ok (Non_inlinable non_inlinable)) ->

--- a/middle_end/flambda2/types/env/typing_env.rec.mli
+++ b/middle_end/flambda2/types/env/typing_env.rec.mli
@@ -143,7 +143,7 @@ val free_names_transitive : t -> Type_grammar.t -> Name_occurrences.t
 
 val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
-val to_closure_conversion_approx : t -> get_imported_code:(unit -> Exported_code.t) -> Value_approximation.t Symbol.Map.t
+val to_closure_conversion_approx : t -> Symbol.t -> Value_approximation.t
 
 module Serializable : sig
   type typing_env = t

--- a/middle_end/flambda2/types/env/typing_env.rec.mli
+++ b/middle_end/flambda2/types/env/typing_env.rec.mli
@@ -143,6 +143,8 @@ val free_names_transitive : t -> Type_grammar.t -> Name_occurrences.t
 
 val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
+val to_closure_conversion_approx : t -> Value_approximation.t Symbol.Map.t
+
 module Serializable : sig
   type typing_env = t
 
@@ -161,14 +163,6 @@ module Serializable : sig
     get_imported_names:(unit -> Name.Set.t) ->
     get_imported_code:(unit -> Exported_code.t) ->
     typing_env
-
-  val to_closure_conversion_approx :
-    t ->
-    Flambda.Code.t Code_id.Map.t ->
-    resolver:(Compilation_unit.t -> typing_env option) ->
-    get_imported_names:(unit -> Name.Set.t) ->
-    get_imported_code:(unit -> Exported_code.t) ->
-    Value_approximation.t Symbol.Map.t
 
   val all_ids_for_export : t -> Ids_for_export.t
 

--- a/middle_end/flambda2/types/env/typing_env.rec.mli
+++ b/middle_end/flambda2/types/env/typing_env.rec.mli
@@ -143,7 +143,7 @@ val free_names_transitive : t -> Type_grammar.t -> Name_occurrences.t
 
 val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
-val to_closure_conversion_approx : t -> Value_approximation.t Symbol.Map.t
+val to_closure_conversion_approx : t -> get_imported_code:(unit -> Exported_code.t) -> Value_approximation.t Symbol.Map.t
 
 module Serializable : sig
   type typing_env = t

--- a/middle_end/flambda2/types/env/typing_env.rec.mli
+++ b/middle_end/flambda2/types/env/typing_env.rec.mli
@@ -150,6 +150,9 @@ module Serializable : sig
 
   val create : typing_env -> t
 
+  val create_from_closure_conversion_approx :
+    Value_approximation.t Symbol.Map.t -> t
+
   val print : Format.formatter -> t -> unit
 
   val to_typing_env :
@@ -158,6 +161,14 @@ module Serializable : sig
     get_imported_names:(unit -> Name.Set.t) ->
     get_imported_code:(unit -> Exported_code.t) ->
     typing_env
+
+  val to_closure_conversion_approx :
+    t ->
+    Flambda.Code.t Code_id.Map.t ->
+    resolver:(Compilation_unit.t -> typing_env option) ->
+    get_imported_names:(unit -> Name.Set.t) ->
+    get_imported_code:(unit -> Exported_code.t) ->
+    Value_approximation.t Symbol.Map.t
 
   val all_ids_for_export : t -> Ids_for_export.t
 

--- a/middle_end/flambda2/types/flambda_type.mli
+++ b/middle_end/flambda2/types/flambda_type.mli
@@ -180,6 +180,8 @@ module Typing_env : sig
 
   val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
+  val to_closure_conversion_approx : t -> Value_approximation.t Symbol.Map.t
+
   module Serializable : sig
     type typing_env = t
 
@@ -198,14 +200,6 @@ module Typing_env : sig
       get_imported_names:(unit -> Name.Set.t) ->
       get_imported_code:(unit -> Exported_code.t) ->
       typing_env
-
-    val to_closure_conversion_approx :
-      t ->
-      Flambda.Code.t Code_id.Map.t ->
-      resolver:(Compilation_unit.t -> typing_env option) ->
-      get_imported_names:(unit -> Name.Set.t) ->
-      get_imported_code:(unit -> Exported_code.t) ->
-      Value_approximation.t Symbol.Map.t
 
     val all_ids_for_export : t -> Ids_for_export.t
 

--- a/middle_end/flambda2/types/flambda_type.mli
+++ b/middle_end/flambda2/types/flambda_type.mli
@@ -180,7 +180,7 @@ module Typing_env : sig
 
   val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
-  val to_closure_conversion_approx : t -> Value_approximation.t Symbol.Map.t
+  val to_closure_conversion_approx : t -> get_imported_code:(unit -> Exported_code.t) -> Value_approximation.t Symbol.Map.t
 
   module Serializable : sig
     type typing_env = t

--- a/middle_end/flambda2/types/flambda_type.mli
+++ b/middle_end/flambda2/types/flambda_type.mli
@@ -180,7 +180,7 @@ module Typing_env : sig
 
   val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
-  val to_closure_conversion_approx : t -> get_imported_code:(unit -> Exported_code.t) -> Value_approximation.t Symbol.Map.t
+  val to_closure_conversion_approx : t -> Symbol.t -> Value_approximation.t
 
   module Serializable : sig
     type typing_env = t

--- a/middle_end/flambda2/types/flambda_type.mli
+++ b/middle_end/flambda2/types/flambda_type.mli
@@ -187,6 +187,9 @@ module Typing_env : sig
 
     val create : typing_env -> t
 
+    val create_from_closure_conversion_approx :
+      Value_approximation.t Symbol.Map.t -> t
+
     val print : Format.formatter -> t -> unit
 
     val to_typing_env :
@@ -195,6 +198,14 @@ module Typing_env : sig
       get_imported_names:(unit -> Name.Set.t) ->
       get_imported_code:(unit -> Exported_code.t) ->
       typing_env
+
+    val to_closure_conversion_approx :
+      t ->
+      Flambda.Code.t Code_id.Map.t ->
+      resolver:(Compilation_unit.t -> typing_env option) ->
+      get_imported_names:(unit -> Name.Set.t) ->
+      get_imported_code:(unit -> Exported_code.t) ->
+      Value_approximation.t Symbol.Map.t
 
     val all_ids_for_export : t -> Ids_for_export.t
 

--- a/middle_end/flambda2/types/structures/function_declaration_type.rec.ml
+++ b/middle_end/flambda2/types/structures/function_declaration_type.rec.ml
@@ -103,6 +103,9 @@ let create ~code ~rec_info =
   in
   t, inlining_decision
 
+let create_inlinable ~code_id ~rec_info : t =
+  Ok (Inlinable { code_id; rec_info; must_be_inlined = false })
+
 let create_non_inlinable ~code_id : t = Ok (Non_inlinable { code_id })
 
 let print_t0 ppf t0 =

--- a/middle_end/flambda2/types/structures/function_declaration_type.rec.mli
+++ b/middle_end/flambda2/types/structures/function_declaration_type.rec.mli
@@ -45,6 +45,8 @@ val create :
 
 val create_non_inlinable : code_id:Code_id.t -> t
 
+val create_inlinable : code_id:Code_id.t -> rec_info:Type_grammar.t -> t
+
 include
   Type_structure_intf.S
     with type t := t

--- a/middle_end/flambda2/types/type_grammar.rec.ml
+++ b/middle_end/flambda2/types/type_grammar.rec.ml
@@ -679,6 +679,9 @@ let create_function_declaration ~code ~rec_info =
 let create_non_inlinable_function_declaration ~code_id =
   Function_declaration_type.create_non_inlinable ~code_id
 
+let create_inlinable_function_declaration ~code_id ~rec_info =
+  Function_declaration_type.create_inlinable ~code_id ~rec_info
+
 let exactly_this_closure closure_id ~all_function_decls_in_set:function_decls
     ~all_closures_in_set:closure_types
     ~all_closure_vars_in_set:closure_var_types =

--- a/middle_end/flambda2/types/type_grammar.rec.mli
+++ b/middle_end/flambda2/types/type_grammar.rec.mli
@@ -208,6 +208,9 @@ val create_function_declaration :
 val create_non_inlinable_function_declaration :
   code_id:Code_id.t -> Function_declaration_type.t
 
+val create_inlinable_function_declaration :
+  code_id:Code_id.t -> rec_info:t -> Function_declaration_type.t
+
 val exactly_this_closure :
   Closure_id.t ->
   all_function_decls_in_set:Function_declaration_type.t Closure_id.Map.t ->


### PR DESCRIPTION
Two new functions are exposed in `Flambda_type.Typing_env.Serializable`: `create_from_closure_conversion_approx` and `to_closure_conversion_approx`.

You should be able to use them in `Flambda_cmx` to perform conversions.