### PR TITLE
Add Value_symbol approximation

### DIFF
--- a/middle_end/flambda2/classic_mode_types/dune
+++ b/middle_end/flambda2/classic_mode_types/dune
@@ -1,0 +1,17 @@
+(include_subdirs unqualified)
+
+(library
+ (name flambda2_classic_mode_types)
+ (wrapped false)
+ (flags
+  (:standard
+   -principal
+   -nostdlib
+   -open
+   Flambda2_identifiers))
+ (ocamlopt_flags
+  (:standard -O3))
+ (libraries
+  stdlib
+  ocamlcommon
+  flambda2_identifiers))

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -20,9 +20,10 @@
 
 type 'code t =
   | Value_unknown
+  | Value_symbol of Symbol.t
   | Closure_approximation of Code_id.t * Closure_id.t * 'code
   | Block_approximation of 'code t array
 
 let is_unknown = function
   | Value_unknown -> true
-  | Closure_approximation _ | Block_approximation _ -> false
+  | Value_symbol _ | Closure_approximation _ | Block_approximation _ -> false

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*            Pierre Chambart and Vincent Laviron, OCamlPro               *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Approximations used for cross-module inlining in Closure_conversion *)
+
+type 'code t =
+  | Value_unknown
+  | Closure_approximation of Code_id.t * 'code option
+  | Block_approximation of 'code t array
+
+let is_unknown = function
+  | Value_unknown -> true
+  | Closure_approximation _ | Block_approximation _ -> false

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -20,7 +20,7 @@
 
 type 'code t =
   | Value_unknown
-  | Closure_approximation of Code_id.t * 'code option
+  | Closure_approximation of Code_id.t * 'code
   | Block_approximation of 'code t array
 
 let is_unknown = function

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -20,7 +20,7 @@
 
 type 'code t =
   | Value_unknown
-  | Closure_approximation of Code_id.t * 'code
+  | Closure_approximation of Code_id.t * Closure_id.t * 'code
   | Block_approximation of 'code t array
 
 let is_unknown = function

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -20,6 +20,7 @@
 
 type 'code t =
   | Value_unknown
+  | Value_symbol of Symbol.t
   | Closure_approximation of Code_id.t * Closure_id.t * 'code
   | Block_approximation of 'code t array
 

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -1,0 +1,26 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*            Pierre Chambart and Vincent Laviron, OCamlPro               *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Approximations used for cross-module inlining in Closure_conversion *)
+
+type 'code t =
+  | Value_unknown
+  | Closure_approximation of Code_id.t * 'code option
+  | Block_approximation of 'code t array
+
+val is_unknown : 'a t -> bool

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -20,7 +20,7 @@
 
 type 'code t =
   | Value_unknown
-  | Closure_approximation of Code_id.t * 'code
+  | Closure_approximation of Code_id.t * Closure_id.t * 'code
   | Block_approximation of 'code t array
 
 val is_unknown : 'a t -> bool

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -20,7 +20,7 @@
 
 type 'code t =
   | Value_unknown
-  | Closure_approximation of Code_id.t * 'code option
+  | Closure_approximation of Code_id.t * 'code
   | Block_approximation of 'code t array
 
 val is_unknown : 'a t -> bool

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -63,7 +63,11 @@ let load_symbol_approx loader symbol : Code.t Value_approximation.t =
   | None -> Value_unknown
   | Some typing_env ->
     let find_code code_id =
-      Exported_code.find_code loader.imported_code code_id
+      match Exported_code.find loader.imported_code code_id with
+      | Some (Code_present code) -> Some code
+      | _ -> None
+      (* CR keryan : we want to use metadata in classic mode at some point in
+         the near futur *)
     in
     T.extract_symbol_approx typing_env symbol find_code
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -19,23 +19,28 @@
 module T = Flambda2_types
 module TE = Flambda2_types.Typing_env
 
-let rec load_cmx_file_contents ~get_global_info comp_unit ~imported_units
-    ~imported_names ~imported_code =
-  match Compilation_unit.Map.find comp_unit !imported_units with
+type loader =
+  { get_global_info : Compilation_unit.t -> Flambda_cmx_format.t option;
+    mutable imported_names : Name.Set.t;
+    mutable imported_code : Exported_code.t;
+    mutable imported_units :
+      TE.t option Compilation_unit.Map.t
+  }
+
+let rec load_cmx_file_contents loader comp_unit =
+  match Compilation_unit.Map.find comp_unit loader.imported_units with
   | typing_env_or_none -> typing_env_or_none
   | exception Not_found -> (
-    match get_global_info comp_unit with
+    match loader.get_global_info comp_unit with
     | None ->
       (* To make things easier to think about, we never retry after a .cmx load
          fails. *)
-      imported_units := Compilation_unit.Map.add comp_unit None !imported_units;
+      loader.imported_units
+        <- Compilation_unit.Map.add comp_unit None loader.imported_units;
       None
     | Some cmx ->
-      let resolver comp_unit =
-        load_cmx_file_contents ~get_global_info comp_unit ~imported_names
-          ~imported_code ~imported_units
-      in
-      let get_imported_names () = !imported_names in
+      let resolver comp_unit = load_cmx_file_contents loader comp_unit in
+      let get_imported_names () = loader.imported_names in
       let typing_env, all_code =
         Flambda_cmx_format.import_typing_env_and_code cmx
       in
@@ -43,13 +48,60 @@ let rec load_cmx_file_contents ~get_global_info comp_unit ~imported_units
         TE.Serializable.to_typing_env ~resolver ~get_imported_names typing_env
       in
       let newly_imported_names = TE.name_domain typing_env in
-      imported_names := Name.Set.union newly_imported_names !imported_names;
-      imported_code := Exported_code.merge all_code !imported_code;
+      loader.imported_names
+        <- Name.Set.union newly_imported_names loader.imported_names;
+      loader.imported_code <- Exported_code.merge all_code loader.imported_code;
       let offsets = Flambda_cmx_format.exported_offsets cmx in
       Exported_offsets.import_offsets offsets;
-      imported_units
-        := Compilation_unit.Map.add comp_unit (Some typing_env) !imported_units;
+      loader.imported_units
+        <- Compilation_unit.Map.add comp_unit (Some typing_env)
+             loader.imported_units;
       Some typing_env)
+
+let all_predefined_exception_symbols ~symbol_for_global =
+  Predef.all_predef_exns
+  |> List.map (fun ident ->
+         symbol_for_global
+           ?comp_unit:(Some (Compilation_unit.predefined_exception ()))
+           ident)
+  |> Symbol.Set.of_list
+
+let predefined_exception_typing_env ~symbol_for_global loader =
+  let comp_unit = Compilation_unit.get_current_exn () in
+  Compilation_unit.set_current (Compilation_unit.predefined_exception ());
+  let resolver comp_unit = load_cmx_file_contents loader comp_unit in
+  let get_imported_names () = loader.imported_names in
+  let typing_env =
+    Symbol.Set.fold
+      (fun sym typing_env ->
+        TE.add_definition typing_env (Bound_name.symbol sym) Flambda_kind.value)
+      (all_predefined_exception_symbols ~symbol_for_global)
+      (TE.create ~resolver ~get_imported_names)
+  in
+  Compilation_unit.set_current comp_unit;
+  typing_env
+
+let create_loader ~get_global_info ~symbol_for_global =
+  let loader =
+    { get_global_info;
+      imported_names = Name.Set.empty;
+      imported_code = Exported_code.empty;
+      imported_units = Compilation_unit.Map.empty
+    }
+  in
+  let predefined_exception_typing_env =
+    predefined_exception_typing_env ~symbol_for_global loader
+  in
+  loader.imported_units
+    <- Compilation_unit.Map.singleton
+         (Compilation_unit.predefined_exception ())
+         (Some predefined_exception_typing_env);
+  loader.imported_names <- TE.name_domain predefined_exception_typing_env;
+  loader
+
+let get_imported_names loader () = loader.imported_names
+
+let get_imported_code loader () = loader.imported_code
 
 let compute_reachable_names_and_code ~module_symbol typing_env code =
   let rec fixpoint names_to_add names_already_added =

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -23,8 +23,7 @@ type loader =
   { get_global_info : Compilation_unit.t -> Flambda_cmx_format.t option;
     mutable imported_names : Name.Set.t;
     mutable imported_code : Exported_code.t;
-    mutable imported_units :
-      TE.t option Compilation_unit.Map.t
+    mutable imported_units : TE.t option Compilation_unit.Map.t
   }
 
 let rec load_cmx_file_contents loader comp_unit =
@@ -192,12 +191,13 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol
          ~used_closure_vars)
 
 let prepare_cmx_from_approx ~approxs ~used_closure_vars all_code =
-  if Flambda_features.opaque () then None
+  if Flambda_features.opaque ()
+  then None
   else
     let final_typing_env =
       TE.Serializable.create_from_closure_conversion_approx approxs
     in
-    let exported_offsets =
-      Exported_offsets.imported_offsets ()
-    in
-    Some (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets ~used_closure_vars)
+    let exported_offsets = Exported_offsets.imported_offsets () in
+    Some
+      (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets
+         ~used_closure_vars)

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -66,8 +66,10 @@ let load_symbol_approx loader symbol : Code_or_metadata.t Value_approximation.t
     let find_code code_id =
       match Exported_code.find loader.imported_code code_id with
       | Some code_or_meta -> code_or_meta
-      | _ -> assert false
-      (* CR now : is there a case where this could happen ? *)
+      | _ ->
+        Misc.fatal_errorf
+          "Failed to load informations for %a. Code id not found." Code_id.print
+          code_id
     in
     T.extract_symbol_approx typing_env symbol find_code
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -57,17 +57,17 @@ let rec load_cmx_file_contents loader comp_unit =
              loader.imported_units;
       Some typing_env)
 
-let load_symbol_approx loader symbol : Code.t Value_approximation.t =
+let load_symbol_approx loader symbol : Code_or_metadata.t Value_approximation.t
+    =
   let comp_unit = Symbol.compilation_unit symbol in
   match load_cmx_file_contents loader comp_unit with
   | None -> Value_unknown
   | Some typing_env ->
     let find_code code_id =
       match Exported_code.find loader.imported_code code_id with
-      | Some (Code_present code) -> Some code
-      | _ -> None
-      (* CR keryan : we want to use metadata in classic mode at some point in
-         the near futur *)
+      | Some code_or_meta -> code_or_meta
+      | _ -> assert false
+      (* CR now : is there a case where this could happen ? *)
     in
     T.extract_symbol_approx typing_env symbol find_code
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -58,6 +58,16 @@ let rec load_cmx_file_contents loader comp_unit =
              loader.imported_units;
       Some typing_env)
 
+let load_symbol_approx loader symbol : Code.t Value_approximation.t =
+  let comp_unit = Symbol.compilation_unit symbol in
+  match load_cmx_file_contents loader comp_unit with
+  | None -> Value_unknown
+  | Some typing_env ->
+    let find_code code_id =
+      Exported_code.find_code loader.imported_code code_id
+    in
+    T.extract_symbol_approx typing_env symbol find_code
+
 let all_predefined_exception_symbols ~symbol_for_global =
   Predef.all_predef_exns
   |> List.map (fun ident ->
@@ -180,3 +190,14 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol
     Some
       (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets
          ~used_closure_vars)
+
+let prepare_cmx_from_approx ~approxs ~used_closure_vars all_code =
+  if Flambda_features.opaque () then None
+  else
+    let final_typing_env =
+      TE.Serializable.create_from_closure_conversion_approx approxs
+    in
+    let exported_offsets =
+      Exported_offsets.imported_offsets ()
+    in
+    Some (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets ~used_closure_vars)

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -19,14 +19,21 @@
 (** Dumping and restoring of simplification environment information to and from
     .cmx files. *)
 
-val load_cmx_file_contents :
+type loader
+
+val create_loader :
   get_global_info:
     (Flambda2_identifiers.Compilation_unit.t -> Flambda_cmx_format.t option) ->
-  Compilation_unit.t ->
-  imported_units:Flambda2_types.Typing_env.t option Compilation_unit.Map.t ref ->
-  imported_names:Name.Set.t ref ->
-  imported_code:Exported_code.t ref ->
-  Flambda2_types.Typing_env.t option
+  symbol_for_global:
+    (?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
+  loader
+
+val get_imported_names : loader -> unit -> Name.Set.t
+
+val get_imported_code : loader -> unit -> Exported_code.t
+
+val load_cmx_file_contents :
+  loader -> Compilation_unit.t -> Flambda2_types.Typing_env.t option
 
 val prepare_cmx_file_contents :
   final_typing_env:Flambda2_types.Typing_env.t option ->

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -24,8 +24,7 @@ type loader
 val create_loader :
   get_global_info:
     (Flambda2_identifiers.Compilation_unit.t -> Flambda_cmx_format.t option) ->
-  symbol_for_global:
-    (?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
+  symbol_for_global:(?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
   loader
 
 val get_imported_names : loader -> unit -> Name.Set.t
@@ -35,8 +34,7 @@ val get_imported_code : loader -> unit -> Exported_code.t
 val load_cmx_file_contents :
   loader -> Compilation_unit.t -> Flambda2_types.Typing_env.t option
 
-val load_symbol_approx :
-  loader -> Symbol.t -> Code.t Value_approximation.t
+val load_symbol_approx : loader -> Symbol.t -> Code.t Value_approximation.t
 
 val prepare_cmx_file_contents :
   final_typing_env:Flambda2_types.Typing_env.t option ->

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -35,9 +35,18 @@ val get_imported_code : loader -> unit -> Exported_code.t
 val load_cmx_file_contents :
   loader -> Compilation_unit.t -> Flambda2_types.Typing_env.t option
 
+val load_symbol_approx :
+  loader -> Symbol.t -> Code.t Value_approximation.t
+
 val prepare_cmx_file_contents :
   final_typing_env:Flambda2_types.Typing_env.t option ->
   module_symbol:Symbol.t ->
+  used_closure_vars:Var_within_closure.Set.t ->
+  Exported_code.t ->
+  Flambda_cmx_format.t option
+
+val prepare_cmx_from_approx :
+  approxs:Code.t Value_approximation.t Symbol.Map.t ->
   used_closure_vars:Var_within_closure.Set.t ->
   Exported_code.t ->
   Flambda_cmx_format.t option

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -34,7 +34,8 @@ val get_imported_code : loader -> unit -> Exported_code.t
 val load_cmx_file_contents :
   loader -> Compilation_unit.t -> Flambda2_types.Typing_env.t option
 
-val load_symbol_approx : loader -> Symbol.t -> Code.t Value_approximation.t
+val load_symbol_approx :
+  loader -> Symbol.t -> Code_or_metadata.t Value_approximation.t
 
 val prepare_cmx_file_contents :
   final_typing_env:Flambda2_types.Typing_env.t option ->
@@ -44,7 +45,7 @@ val prepare_cmx_file_contents :
   Flambda_cmx_format.t option
 
 val prepare_cmx_from_approx :
-  approxs:Code.t Value_approximation.t Symbol.Map.t ->
+  approxs:Code_or_metadata.t Value_approximation.t Symbol.Map.t ->
   used_closure_vars:Var_within_closure.Set.t ->
   Exported_code.t ->
   Flambda_cmx_format.t option

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -158,13 +158,15 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
     in
     Compiler_hooks.execute Raw_flambda2 raw_flambda;
     print_rawflambda ppf raw_flambda;
-    (if Flambda_features.inlining_report ()
-    then
-      let output_prefix = prefixname ^ ".cps_conv" in
-      Inlining_report.output_then_forget_decisions ~output_prefix);
     let flambda, (cmx : Flambda2_cmx.Flambda_cmx_format.t option), all_code =
       if Flambda_features.classic_mode ()
-      then raw_flambda, cmx, code
+      then begin
+        (if Flambda_features.inlining_report ()
+        then
+          let output_prefix = prefixname ^ ".cps_conv" in
+          Inlining_report.output_then_forget_decisions ~output_prefix);
+        raw_flambda, cmx, code
+      end
       else
         let raw_flambda =
           if Flambda_features.Debug.permute_every_name ()

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -169,9 +169,10 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
           else raw_flambda
         in
         let round = 0 in
+        let cmx_loader = Flambda_cmx.create_loader ~get_global_info ~symbol_for_global in
         let { Simplify.unit = flambda; cmx; all_code } =
           Profile.record_call ~accumulate:true "simplify" (fun () ->
-              Simplify.run ~symbol_for_global ~get_global_info ~round
+              Simplify.run ~cmx_loader ~round
                 raw_flambda)
         in
         (if Flambda_features.inlining_report ()

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -169,11 +169,12 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
           else raw_flambda
         in
         let round = 0 in
-        let cmx_loader = Flambda_cmx.create_loader ~get_global_info ~symbol_for_global in
+        let cmx_loader =
+          Flambda_cmx.create_loader ~get_global_info ~symbol_for_global
+        in
         let { Simplify.unit = flambda; cmx; all_code } =
           Profile.record_call ~accumulate:true "simplify" (fun () ->
-              Simplify.run ~cmx_loader ~round
-                raw_flambda)
+              Simplify.run ~cmx_loader ~round raw_flambda)
         in
         (if Flambda_features.inlining_report ()
         then

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1359,10 +1359,13 @@ let close_apply acc env (apply : IR.apply) : Acc.t * Expr_with_acc.t =
         (Code_metadata.params_arity metadata, Code_metadata.is_tupled metadata)
     | Value_unknown -> None
     | _ ->
-      Misc.fatal_errorf
-        "Unexpected approximation for callee %a in [Closure_conversion], \
-         expected a closure approximation."
-        Simple.print callee
+      if Flambda_features.check_invariants ()
+      then
+        Misc.fatal_errorf
+          "Unexpected approximation for callee %a in [Closure_conversion], \
+           expected a closure approximation."
+          Simple.print callee
+      else None
   in
   match arity_and_tupled with
   | None -> close_exact_or_unknown_apply acc env apply None

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1366,9 +1366,7 @@ let close_apply acc env (apply : IR.apply) : Acc.t * Expr_with_acc.t =
   in
   match arity_and_tupled with
   | None -> close_exact_or_unknown_apply acc env apply None
-  | Some (_arity, true) ->
-    close_exact_or_unknown_apply acc env apply (Some approx)
-  | Some (arity, false) -> (
+  | Some (arity, is_tupled) -> (
     let args, missing_args, remaining_args =
       let rec split l1 l2 =
         match l1, l2 with
@@ -1377,6 +1375,13 @@ let close_apply acc env (apply : IR.apply) : Acc.t * Expr_with_acc.t =
         | e1 :: l1, _ :: l2 ->
           let args, missing, remains = split l1 l2 in
           e1 :: args, missing, remains
+      in
+      let arity =
+        if is_tupled
+        then
+          Flambda_arity.With_subkinds.create
+            [Flambda_kind.With_subkind.block Tag.zero arity]
+        else arity
       in
       split apply.args arity
     in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -190,7 +190,6 @@ module Inlining = struct
       Not_inlinable
     | Block_approximation _ -> assert false
     | Closure_approximation (code_id, None) ->
-      (* Format.eprintf "No infos\n"; *)
       Inlining_report.record_decision ~dbg
         (At_call_site
            (Inlining_report.Known_function
@@ -199,7 +198,6 @@ module Inlining = struct
               }));
       Not_inlinable
     | Closure_approximation (code_id, Some code) ->
-      (* Format.eprintf "Some infos\n"; *)
       let fun_params_length =
         Code.params_arity code |> Flambda_arity.With_subkinds.to_arity
         |> Flambda_arity.length
@@ -1410,14 +1408,7 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
   let module_block_approximation =
     match Acc.continuation_known_arguments ~cont:prog_return_cont acc with
     | Some [approx] -> approx
-    | Some l ->
-      Format.eprintf "%a, approx len: %d\n" Continuation.print prog_return_cont
-        (List.length l);
-      assert false
-    | _ ->
-      Format.eprintf "%a, approx len: none\n" Continuation.print
-        prog_return_cont;
-      Value_approximation.Value_unknown
+    | _ -> assert false
   in
   let acc, body =
     Code_id.Map.fold
@@ -1476,13 +1467,12 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
         |> Expr_with_acc.create_let)
       (acc, body) (Acc.declared_symbols acc)
   in
-  let used_closure_vars =
-    (* let vs = *)
-    Name_occurrences.closure_vars (Acc.free_names acc)
-    (*in Format.eprintf "%a\n" Var_within_closure.Set.print vs;
-     * vs *)
+  let used_closure_vars = Name_occurrences.closure_vars (Acc.free_names acc) in
+  let all_code =
+    Exported_code.add_code (Acc.code acc)
+      (Exported_code.mark_as_imported
+         (Flambda_cmx.get_imported_code cmx_loader ()))
   in
-  let all_code = Exported_code.add_code (Acc.code acc) Exported_code.empty in
   let cmx =
     Flambda_cmx.prepare_cmx_from_approx ~approxs:symbols_approximations
       ~used_closure_vars all_code

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -169,16 +169,7 @@ let find_simples acc env ids =
   List.fold_left_map (fun acc id -> find_simple acc env id) acc ids
 
 module Inlining = struct
-  type inlinable_result =
-    | Not_inlinable
-    | Inlinable of Code.t
-
-  let threshold () =
-    let inline_threshold =
-      Clflags.Float_arg_helper.get ~key:0 !Clflags.inline_threshold
-    in
-    let magic_scale_constant = 8. in
-    int_of_float (inline_threshold *. magic_scale_constant)
+  include Closure_conversion_aux.Inlining
 
   (* CR keryan: we need to emit warnings *)
   let inlinable env apply =
@@ -1127,26 +1118,9 @@ let close_one_function acc ~external_env ~by_closure_id decl
   let is_tupled =
     match Function_decl.kind decl with Curried -> false | Tupled -> true
   in
-  let code_size = Cost_metrics.size cost_metrics in
-  let inline_threshold = Inlining.threshold () in
   let inlining_decision =
     if Flambda_features.classic_mode ()
-    then
-      match inline with
-      | Never_inline ->
-        Function_decl_inlining_decision_type.Never_inline_attribute
-      | Always_inline | Available_inline ->
-        Function_decl_inlining_decision_type.Attribute_inline
-      | _ ->
-        if Code_size.to_int code_size <= inline_threshold
-        then
-          Function_decl_inlining_decision_type.Small_function
-            { size = code_size;
-              small_function_size = Code_size.of_int inline_threshold
-            }
-        else
-          Function_decl_inlining_decision_type.Function_body_too_large
-            (Code_size.of_int inline_threshold)
+    then Inlining.definition_inlining_decision inline cost_metrics
     else Function_decl_inlining_decision_type.Not_yet_decided
   in
   let code =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1408,7 +1408,7 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
   let module_block_approximation =
     match Acc.continuation_known_arguments ~cont:prog_return_cont acc with
     | Some [approx] -> approx
-    | _ -> assert false
+    | _ -> Value_approximation.Value_unknown
   in
   let acc, body =
     Code_id.Map.fold
@@ -1445,7 +1445,7 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
     List.fold_left
       (fun sa (symbol, _) ->
         (* CR Keryan: for now only constants are lifted. It will need refinement
-           with thelifting of closed functions *)
+           with the lifting of closed functions *)
         Symbol.Map.add symbol Value_approximation.Value_unknown sa)
       (Symbol.Map.singleton module_symbol module_block_approximation)
       (Acc.declared_symbols acc)
@@ -1478,6 +1478,8 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
       ~used_closure_vars all_code
   in
   ( Flambda_unit.create ~return_continuation:return_cont ~exn_continuation ~body
-      ~module_symbol ~used_closure_vars:(Known used_closure_vars),
+      ~module_symbol ~used_closure_vars:Unknown,
+    (* CR keryan: this should use [used_closure_vars] as well but it doesn't
+       work well with cmx from simplify yet (issue #331) *)
     all_code,
     cmx )

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -32,6 +32,10 @@ module LC = Lambda_conversions
 module P = Flambda_primitive
 module VB = Bound_var
 
+type close_functions_result =
+  | Lifted of (Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t
+  | Dynamic of Set_of_closures.t * Code.t Value_approximation.t Closure_id.Map.t
+
 (* Do not use [Simple.symbol], use this function instead, to ensure that we
    correctly compute the free names of [Code]. *)
 let use_of_symbol_as_simple acc symbol = acc, Simple.symbol symbol
@@ -40,23 +44,14 @@ let symbol_for_ident acc env id =
   let symbol = Env.symbol_for_global env id in
   use_of_symbol_as_simple acc symbol
 
-let register_set_of_closures_as_symbols acc set_of_closures approximations :
-    Acc.t * Symbol.t Closure_id.Lmap.t =
-  let symbols =
-    Set_of_closures.function_decls set_of_closures
-    |> Function_declarations.funs_in_order
-    |> Closure_id.Lmap.mapi (fun closure_id _ ->
-           let symbol =
-             Symbol.create
-               (Compilation_unit.get_current_exn ())
-               (Linkage_name.create
-                  (Variable.unique_name (Closure_id.unwrap closure_id)))
-           in
-           let approx = Closure_id.Map.find closure_id approximations in
-           symbol, approx)
+let declare_symbol_for_closure_ident env ident closure_id : Env.t * Symbol.t =
+  let symbol =
+    Symbol.create
+      (Compilation_unit.get_current_exn ())
+      (Linkage_name.create (Closure_id.to_string closure_id))
   in
-  let acc = Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc in
-  acc, Closure_id.Lmap.map fst symbols
+  let env = Env.add_simple_to_substitute env ident (Simple.symbol symbol) in
+  env, symbol
 
 let register_const0 acc constant name =
   match Static_const.Map.find constant (Acc.shareable_constants acc) with
@@ -926,7 +921,7 @@ let close_switch acc env scrutinee (sw : IR.switch) : Acc.t * Expr_with_acc.t =
         untag ~body
       |> Expr_with_acc.create_let
 
-let close_one_function acc ~external_env ~by_closure_id decl
+let close_one_function acc ~external_env ~by_closure_id decl ~has_lifted_closure
     ~var_within_closures_from_idents ~closure_ids_from_idents
     function_declarations =
   let acc = Acc.with_free_names Name_occurrences.empty acc in
@@ -971,33 +966,44 @@ let close_one_function acc ~external_env ~by_closure_id decl
       ~from:(Rec_info_expr.var my_depth)
       ~to_:(Rec_info_expr.var next_depth)
   in
+  if has_lifted_closure
+     && not (Variable.Map.is_empty var_within_closures_to_bind)
+  then
+    Misc.fatal_errorf
+      "Variables found in closure when trying to lift %a in \
+       [Closure_conversion]."
+      Ident.print our_let_rec_ident;
   (* CR mshinwell: Remove "project_closure" names *)
   let project_closure_to_bind, simples_for_project_closure =
-    List.fold_left
-      (fun (to_bind, simples_for_idents) function_decl ->
-        let let_rec_ident = Function_decl.let_rec_ident function_decl in
-        let to_bind, var =
-          if Ident.same our_let_rec_ident let_rec_ident && is_curried
-          then
-            (* When the function being compiled is tupled, my_closure points to
-               the curried version but let_rec_ident is called with tuple
-               arguments, so the correct closure to bind is the one in the
-               closure_ids_from_idents map. *)
-            to_bind, my_closure
-            (* my_closure is already bound *)
-          else
-            let variable =
-              Variable.create_with_same_name_as_ident let_rec_ident
-            in
-            let closure_id =
-              Ident.Map.find let_rec_ident closure_ids_from_idents
-            in
-            Variable.Map.add variable closure_id to_bind, variable
-        in
-        let simple = Simple.with_coercion (Simple.var var) coerce_to_deeper in
-        to_bind, Ident.Map.add let_rec_ident simple simples_for_idents)
-      (Variable.Map.empty, Ident.Map.empty)
-      (Function_decls.to_list function_declarations)
+    if has_lifted_closure
+    then (* No projection needed *)
+      Variable.Map.empty, Ident.Map.empty
+    else
+      List.fold_left
+        (fun (to_bind, simples_for_idents) function_decl ->
+          let let_rec_ident = Function_decl.let_rec_ident function_decl in
+          let to_bind, var =
+            if Ident.same our_let_rec_ident let_rec_ident && is_curried
+            then
+              (* When the function being compiled is tupled, my_closure points
+                 to the curried version but let_rec_ident is called with tuple
+                 arguments, so the correct closure to bind is the one in the
+                 closure_ids_from_idents map. *)
+              to_bind, my_closure
+              (* my_closure is already bound *)
+            else
+              let variable =
+                Variable.create_with_same_name_as_ident let_rec_ident
+              in
+              let closure_id =
+                Ident.Map.find let_rec_ident closure_ids_from_idents
+              in
+              Variable.Map.add variable closure_id to_bind, variable
+          in
+          let simple = Simple.with_coercion (Simple.var var) coerce_to_deeper in
+          to_bind, Ident.Map.add let_rec_ident simple simples_for_idents)
+        (Variable.Map.empty, Ident.Map.empty)
+        (Function_decls.to_list function_declarations)
   in
   let closure_env_without_parameters =
     let empty_env = Env.clear_local_bindings external_env in
@@ -1203,6 +1209,7 @@ let close_functions acc external_env function_declarations =
       (Function_decls.all_free_idents function_declarations)
       Ident.Map.empty
   in
+  let can_be_lifted = Ident.Map.is_empty var_within_closures_from_idents in
   let func_decl_list = Function_decls.to_list function_declarations in
   let closure_ids_from_idents =
     List.fold_left
@@ -1212,12 +1219,26 @@ let close_functions acc external_env function_declarations =
         Ident.Map.add id closure_id map)
       Ident.Map.empty func_decl_list
   in
+  let external_env, symbol_map =
+    if can_be_lifted
+    then
+      Ident.Map.fold
+        (fun ident closure_id (env, symbol_map) ->
+          let env, symbol =
+            declare_symbol_for_closure_ident env ident closure_id
+          in
+          env, Closure_id.Map.add closure_id symbol symbol_map)
+        closure_ids_from_idents
+        (external_env, Closure_id.Map.empty)
+    else external_env, Closure_id.Map.empty
+  in
   let acc, approximations =
     List.fold_left
       (fun (acc, by_closure_id) function_decl ->
         let _, _, acc, expr =
           Acc.measure_cost_metrics acc ~f:(fun acc ->
               close_one_function acc ~external_env ~by_closure_id function_decl
+                ~has_lifted_closure:can_be_lifted
                 ~var_within_closures_from_idents ~closure_ids_from_idents
                 function_declarations)
         in
@@ -1236,6 +1257,12 @@ let close_functions acc external_env function_declarations =
     in
     Closure_id.Lmap.of_list (List.rev funs)
   in
+  let approximations =
+    Closure_id.Map.map
+      (fun (code_id, code) ->
+        Value_approximation.Closure_approximation (code_id, code))
+      approximations
+  in
   let function_decls = Function_declarations.create funs in
   let closure_elements =
     Ident.Map.fold
@@ -1247,7 +1274,21 @@ let close_functions acc external_env function_declarations =
         Var_within_closure.Map.add var_within_closure external_simple map)
       var_within_closures_from_idents Var_within_closure.Map.empty
   in
-  acc, Set_of_closures.create function_decls ~closure_elements, approximations
+  let set_of_closures =
+    Set_of_closures.create function_decls ~closure_elements
+  in
+  if can_be_lifted
+  then
+    let symbols =
+      Closure_id.Lmap.mapi
+        (fun closure_id _ ->
+          ( Closure_id.Map.find closure_id symbol_map,
+            Closure_id.Map.find closure_id approximations ))
+        funs
+    in
+    let acc = Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc in
+    acc, Lifted symbols
+  else acc, Dynamic (set_of_closures, approximations)
 
 let close_let_rec acc env ~function_declarations
     ~(body : Acc.t -> Env.t -> Acc.t * Expr_with_acc.t) =
@@ -1270,49 +1311,15 @@ let close_let_rec acc env ~function_declarations
       (Closure_id.Map.empty, Closure_id.Map.empty)
       function_declarations
   in
-  let acc, set_of_closures, approximations =
+  let acc, closed_functions =
     close_functions acc env (Function_decls.create function_declarations)
   in
-  let approximations =
-    Closure_id.Map.map
-      (fun (code_id, code) ->
-        Value_approximation.Closure_approximation (code_id, code))
-      approximations
-  in
-  (* CR mshinwell: We should maybe have something more elegant here *)
-  let generated_closures =
-    Closure_id.Set.diff
-      (Closure_id.Map.keys
-         (Function_declarations.funs
-            (Set_of_closures.function_decls set_of_closures)))
-      (Closure_id.Map.keys closure_vars)
-  in
-  let closure_vars_map =
-    Closure_id.Set.fold
-      (fun closure_id closure_vars ->
-        let closure_var =
-          VB.create (Variable.create "generated") Name_mode.normal
-        in
-        Closure_id.Map.add closure_id closure_var closure_vars)
-      generated_closures closure_vars
-  in
-  let closure_vars =
-    List.map
-      (fun (closure_id, _) -> Closure_id.Map.find closure_id closure_vars_map)
-      (Function_declarations.funs_in_order
-         (Set_of_closures.function_decls set_of_closures)
-      |> Closure_id.Lmap.bindings)
-  in
-  if Set_of_closures.environment_doesn't_mention_variables set_of_closures
-  then
-    let acc, symbols =
-      register_set_of_closures_as_symbols acc set_of_closures approximations
-    in
+  match closed_functions with
+  | Lifted symbols ->
     let env =
       Closure_id.Lmap.fold
-        (fun closure_id symbol env ->
+        (fun closure_id (symbol, approx) env ->
           let ident = Closure_id.Map.find closure_id ident_map in
-          let approx = Closure_id.Map.find closure_id approximations in
           let env =
             Env.add_simple_to_substitute env ident (Simple.symbol symbol)
           in
@@ -1320,7 +1327,31 @@ let close_let_rec acc env ~function_declarations
         symbols env
     in
     body acc env
-  else
+  | Dynamic (set_of_closures, approximations) ->
+    (* CR mshinwell: We should maybe have something more elegant here *)
+    let generated_closures =
+      Closure_id.Set.diff
+        (Closure_id.Map.keys
+           (Function_declarations.funs
+              (Set_of_closures.function_decls set_of_closures)))
+        (Closure_id.Map.keys closure_vars)
+    in
+    let closure_vars_map =
+      Closure_id.Set.fold
+        (fun closure_id closure_vars ->
+          let closure_var =
+            VB.create (Variable.create "generated") Name_mode.normal
+          in
+          Closure_id.Map.add closure_id closure_var closure_vars)
+        generated_closures closure_vars
+    in
+    let closure_vars =
+      List.map
+        (fun (closure_id, _) -> Closure_id.Map.find closure_id closure_vars_map)
+        (Function_declarations.funs_in_order
+           (Set_of_closures.function_decls set_of_closures)
+        |> Closure_id.Lmap.bindings)
+    in
     let env =
       Closure_id.Map.fold
         (fun closure_id var env ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1209,7 +1209,10 @@ let close_functions acc external_env function_declarations =
       (Function_decls.all_free_idents function_declarations)
       Ident.Map.empty
   in
-  let can_be_lifted = Ident.Map.is_empty var_within_closures_from_idents in
+  let can_be_lifted =
+    Ident.Map.is_empty var_within_closures_from_idents
+    && Flambda_features.classic_mode ()
+  in
   let func_decl_list = Function_decls.to_list function_declarations in
   let closure_ids_from_idents =
     List.fold_left

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -191,7 +191,7 @@ module Inlining = struct
     | None | Some Value_unknown ->
       Inlining_report.(record_decision ~dbg (At_call_site Unknown_function));
       Not_inlinable
-    | Some (Block_approximation _) -> assert false
+    | Some (Value_symbol _) | Some (Block_approximation _) -> assert false
     | Some (Closure_approximation (code_id, _, Metadata_only _)) ->
       Inlining_report.record_decision ~dbg
         (At_call_site
@@ -644,13 +644,14 @@ let close_let acc env id user_visible defining_expr
         match defining_expr with
         | Prim (Variadic (Make_block (_, Immutable), fields), _) ->
           let approxs =
-            List.map (Env.find_value_approximation body_env) fields
-            |> Array.of_list
+            List.map (Env.value_approximation body_env) fields |> Array.of_list
           in
           Env.add_block_approximation body_env (Name.var var) approxs
         | Prim (Binary (Block_load _, block, field), _) -> begin
           match Env.find_value_approximation body_env block with
           | Value_unknown -> body_env
+          | Value_symbol _ ->
+            assert false (* find_value_approximation resolves symbols *)
           | Closure_approximation _ ->
             Misc.fatal_errorf
               "Closure approximation found when block approximation was \
@@ -1654,10 +1655,28 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
       acc
   in
   let symbols_approximations =
+    let approx_of_field (field : Field_of_static_block.t) :
+        _ Value_approximation.t =
+      match field with
+      | Symbol sym -> Value_symbol sym
+      | Tagged_immediate _ | Dynamically_computed _ -> Value_unknown
+    in
+    let approx_of_static_const (const : Static_const.t) :
+        _ Value_approximation.t =
+      match const with
+      | Set_of_closures _ -> Value_unknown (* tracked separately *)
+      | Block (_, (Immutable_unique | Mutable), _) -> Value_unknown
+      | Block (_tag, Immutable, fields) ->
+        Block_approximation (Array.of_list (List.map approx_of_field fields))
+      | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _ | Boxed_nativeint _
+      | Immutable_float_block _ | Immutable_float_array _ | Mutable_string _
+      | Immutable_string _ ->
+        Value_unknown
+    in
     let symbol_approxs =
       List.fold_left
-        (fun sa (symbol, _) ->
-          Symbol.Map.add symbol Value_approximation.Value_unknown sa)
+        (fun sa (symbol, const) ->
+          Symbol.Map.add symbol (approx_of_static_const const) sa)
         (Symbol.Map.singleton module_symbol module_block_approximation)
         (Acc.declared_symbols acc)
     in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -690,7 +690,7 @@ let close_let acc env id user_visible defining_expr
                expected in [Closure_conversion]: %a"
               Named.print defining_expr
           | Block_approximation approx ->
-            let approx : Env.value_approximation =
+            let approx =
               Simple.pattern_match field
                 ~const:(fun const ->
                   match Reg_width_things.Const.descr const with
@@ -703,8 +703,8 @@ let close_let acc env id user_visible defining_expr
                          approximation of length %d."
                         i (Array.length approx);
                     approx.(i)
-                  | _ -> Env.Value_unknown)
-                ~name:(fun _ ~coercion:_ -> Env.Value_unknown)
+                  | _ -> Value_approximation.Value_unknown)
+                ~name:(fun _ ~coercion:_ -> Value_approximation.Value_unknown)
             in
             Env.add_value_approximation body_env (Name.var var) approx
         end

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -40,6 +40,20 @@ let symbol_for_ident acc env id =
   let symbol = Env.symbol_for_global env id in
   use_of_symbol_as_simple acc symbol
 
+let register_set_of_closures_as_symbols acc set_of_closures :
+    Acc.t * Symbol.t Closure_id.Lmap.t =
+  let symbols =
+    Set_of_closures.function_decls set_of_closures
+    |> Function_declarations.funs_in_order
+    |> Closure_id.Lmap.mapi (fun closure_id _ ->
+           Symbol.create
+             (Compilation_unit.get_current_exn ())
+             (Linkage_name.create
+                (Variable.unique_name (Closure_id.unwrap closure_id))))
+  in
+  let acc = Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc in
+  acc, symbols
+
 let register_const0 acc constant name =
   match Static_const.Map.find constant (Acc.shareable_constants acc) with
   | exception Not_found ->
@@ -1210,14 +1224,13 @@ let close_functions acc external_env function_declarations =
   let acc = Acc.with_free_names Name_occurrences.empty acc in
   (* CR lmaurer: funs has arbitrary order (ultimately coming from
      function_declarations) *)
-  let funs, approximations =
-    let funs, approxs =
+  let funs =
+    let funs =
       Closure_id.Map.fold
-        (fun cid (code_id, desc) (funs, approxs) ->
-          (cid, code_id) :: funs, (code_id, desc) :: approxs)
-        approximations ([], [])
+        (fun cid (code_id, _) funs -> (cid, code_id) :: funs)
+        approximations []
     in
-    Closure_id.Lmap.of_list (List.rev funs), List.rev approxs
+    Closure_id.Lmap.of_list (List.rev funs)
   in
   let function_decls = Function_declarations.create funs in
   let closure_elements =
@@ -1242,17 +1255,16 @@ let close_let_rec acc env ~function_declarations
         env)
       function_declarations env
   in
-  let closure_vars =
+  let closure_vars, ident_map =
     List.fold_left
-      (fun closure_vars decl ->
-        let closure_var =
-          VB.create
-            (Env.find_var env (Function_decl.let_rec_ident decl))
-            Name_mode.normal
-        in
+      (fun (closure_vars, ident_map) decl ->
+        let ident = Function_decl.let_rec_ident decl in
+        let closure_var = VB.create (Env.find_var env ident) Name_mode.normal in
         let closure_id = Function_decl.closure_id decl in
-        Closure_id.Map.add closure_id closure_var closure_vars)
-      Closure_id.Map.empty function_declarations
+        ( Closure_id.Map.add closure_id closure_var closure_vars,
+          Closure_id.Map.add closure_id ident ident_map ))
+      (Closure_id.Map.empty, Closure_id.Map.empty)
+      function_declarations
   in
   let acc, set_of_closures, approximations =
     close_functions acc env (Function_decls.create function_declarations)
@@ -1265,7 +1277,7 @@ let close_let_rec acc env ~function_declarations
             (Set_of_closures.function_decls set_of_closures)))
       (Closure_id.Map.keys closure_vars)
   in
-  let closure_vars =
+  let closure_vars_map =
     Closure_id.Set.fold
       (fun closure_id closure_vars ->
         let closure_var =
@@ -1276,23 +1288,42 @@ let close_let_rec acc env ~function_declarations
   in
   let closure_vars =
     List.map
-      (fun (closure_id, _) -> Closure_id.Map.find closure_id closure_vars)
+      (fun (closure_id, _) -> Closure_id.Map.find closure_id closure_vars_map)
       (Function_declarations.funs_in_order
          (Set_of_closures.function_decls set_of_closures)
       |> Closure_id.Lmap.bindings)
   in
-  let env =
-    List.fold_left2
-      (fun env var approx ->
-        Env.add_closure_approximation env (Name.var (VB.var var)) approx)
-      env closure_vars approximations
-  in
-  let acc, body = body acc env in
-  let named = Named.create_set_of_closures set_of_closures in
-  Let_with_acc.create acc
-    (Bound_pattern.set_of_closures ~closure_vars)
-    named ~body
-  |> Expr_with_acc.create_let
+  if Set_of_closures.environment_doesn't_mention_variables set_of_closures
+  then
+    let acc, symbols =
+      register_set_of_closures_as_symbols acc set_of_closures
+    in
+    let env =
+      Closure_id.Lmap.fold
+        (fun closure_id symbol env ->
+          let ident = Closure_id.Map.find closure_id ident_map in
+          let approx = Closure_id.Map.find closure_id approximations in
+          let env =
+            Env.add_simple_to_substitute env ident (Simple.symbol symbol)
+          in
+          Env.add_closure_approximation env (Name.symbol symbol) approx)
+        symbols env
+    in
+    body acc env
+  else
+    let env =
+      Closure_id.Map.fold
+        (fun closure_id var env ->
+          let approx = Closure_id.Map.find closure_id approximations in
+          Env.add_closure_approximation env (Name.var (VB.var var)) approx)
+        closure_vars_map env
+    in
+    let acc, body = body acc env in
+    let named = Named.create_set_of_closures set_of_closures in
+    Let_with_acc.create acc
+      (Bound_pattern.set_of_closures ~closure_vars)
+      named ~body
+    |> Expr_with_acc.create_let
 
 let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
     ~module_block_size_in_words ~program ~prog_return_cont ~exn_continuation =
@@ -1385,6 +1416,28 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
     | _ -> Value_approximation.Value_unknown
   in
   let acc, body =
+    List.fold_left
+      (fun (acc, body) (symbols, set_of_closures) ->
+        let bound_symbols =
+          Bound_symbols.singleton
+            (Bound_symbols.Pattern.set_of_closures symbols)
+        in
+        let defining_expr =
+          Named.create_static_consts
+            (Static_const_group.create
+               [ Static_const_or_code.create_static_const
+                   (Set_of_closures set_of_closures) ])
+        in
+        Let_with_acc.create acc
+          (Bound_pattern.symbols bound_symbols)
+          defining_expr ~body
+        |> Expr_with_acc.create_let)
+      (acc, body)
+      (Acc.declared_static_sets_of_closures acc)
+  in
+  let acc, body =
+    (* CR Keryan: The order of the bindings is important as blocks of code might
+       refer one another. There should be a topological sort here. *)
     Code_id.Map.fold
       (fun code_id code (acc, body) ->
         let bound_symbols =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -739,13 +739,17 @@ let close_exact_or_unknown_apply acc env
   let callee = find_simple_from_id env func in
   let acc, call_kind =
     match kind with
-    | Function ->
-      acc,
-      begin match (callee_approx : Env.value_approximation option) with
+    | Function -> (
+      ( acc,
+        match (callee_approx : Env.value_approximation option) with
         | Some (Closure_approximation (code_id, closure_id, code_or_meta)) ->
-          let param_arity,return_arity, is_tupled, _closure_used =
+          let param_arity, return_arity, is_tupled, _closure_used =
             let meta = Code_or_metadata.code_metadata code_or_meta in
-            Code_metadata.(params_arity meta, result_arity meta, is_tupled meta, is_my_closure_used meta)
+            Code_metadata.(
+              ( params_arity meta,
+                result_arity meta,
+                is_tupled meta,
+                is_my_closure_used meta ))
           in
           if is_tupled
           then
@@ -753,12 +757,12 @@ let close_exact_or_unknown_apply acc env
               Flambda_arity.With_subkinds.create
                 [Flambda_kind.With_subkind.block Tag.zero param_arity]
             in
-            Call_kind.indirect_function_call_known_arity ~param_arity ~return_arity
+            Call_kind.indirect_function_call_known_arity ~param_arity
+              ~return_arity
           else Call_kind.direct_function_call code_id closure_id ~return_arity
-        | None ->
-          Call_kind.indirect_function_call_unknown_arity ()
-        | _ -> assert false (* See [close_apply] *)
-      end
+        | None -> Call_kind.indirect_function_call_unknown_arity ()
+        | _ -> assert false
+        (* See [close_apply] *) ))
     | Method { kind; obj } ->
       let acc, obj = find_simple acc env obj in
       acc, Call_kind.method_call (LC.method_kind kind) ~obj

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -67,9 +67,10 @@ val close_switch :
 val close_program :
   symbol_for_global:(?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
   big_endian:bool ->
+  cmx_loader:Flambda_cmx.loader ->
   module_ident:Ident.t ->
   module_block_size_in_words:int ->
   program:(Acc.t -> Env.t -> Acc.t * Expr_with_acc.t) ->
   prog_return_cont:Continuation.t ->
   exn_continuation:Continuation.t ->
-  Flambda_unit.t * Exported_code.t
+  Flambda_unit.t * Exported_code.t * Flambda_cmx_format.t option

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -97,6 +97,8 @@ module Env = struct
       current_depth : Variable.t option;
       symbol_for_global : Ident.t -> Symbol.t;
       value_approximations : Code.t Value_approximation.t Name.Map.t;
+      approximation_for_external_symbol :
+        Symbol.t -> Code.t Value_approximation.t;
       big_endian : bool
     }
 
@@ -108,7 +110,17 @@ module Env = struct
 
   let current_depth t = t.current_depth
 
-  let create ~symbol_for_global ~big_endian =
+  let approximation_loader loader =
+    let externals = ref Symbol.Map.empty in
+    fun symbol ->
+      match Symbol.Map.find symbol !externals with
+      | approx -> approx
+      | exception Not_found ->
+        let approx = Flambda_cmx.load_symbol_approx loader symbol in
+        externals := Symbol.Map.add symbol approx !externals;
+        approx
+
+  let create ~symbol_for_global ~big_endian ~cmx_loader =
     let compilation_unit = Compilation_unit.get_current_exn () in
     { variables = Ident.Map.empty;
       globals = Numeric_types.Int.Map.empty;
@@ -116,6 +128,7 @@ module Env = struct
       current_unit_id = Compilation_unit.get_persistent_ident compilation_unit;
       current_depth = None;
       value_approximations = Name.Map.empty;
+      approximation_for_external_symbol = approximation_loader cmx_loader;
       symbol_for_global;
       big_endian
     }
@@ -128,6 +141,7 @@ module Env = struct
         symbol_for_global;
         current_depth;
         value_approximations;
+        approximation_for_external_symbol;
         big_endian
       } =
     let simples_to_substitute =
@@ -141,6 +155,7 @@ module Env = struct
       current_unit_id;
       current_depth;
       value_approximations;
+      approximation_for_external_symbol;
       symbol_for_global;
       big_endian
     }
@@ -242,7 +257,10 @@ module Env = struct
       ~const:(fun _ -> Value_approximation.Value_unknown)
       ~name:(fun name ~coercion:_ ->
         try Name.Map.find name t.value_approximations
-        with Not_found -> Value_approximation.Value_unknown)
+        with Not_found ->
+          Name.pattern_match name
+            ~var:(fun _ -> Value_approximation.Value_unknown)
+            ~symbol:t.approximation_for_external_symbol)
 
   let add_approximation_alias t name alias =
     match find_value_approximation t (Simple.name name) with
@@ -350,9 +368,10 @@ module Acc = struct
 
   let remove_continuation_from_free_names cont t =
     { t with
-      free_names = Name_occurrences.remove_continuation t.free_names cont;
-      continuation_applications =
-        Continuation.Map.remove cont t.continuation_applications
+      free_names =
+        Name_occurrences.remove_continuation t.free_names cont
+        (* continuation_applications =
+         *   Continuation.Map.remove cont t.continuation_applications *)
     }
 
   let remove_code_id_from_free_names code_id t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -148,9 +148,20 @@ module Env = struct
       | approx -> approx
       | exception Not_found ->
         let approx = Flambda_cmx.load_symbol_approx loader symbol in
+        (if Flambda_features.check_invariants ()
+        then
+          match approx with
+          | Value_symbol sym ->
+            Misc.fatal_errorf
+              "Closure_conversion: approximation loader returned a Symbol \
+               approximation (%a) for symbol %a"
+              Symbol.print sym Symbol.print symbol
+          | Value_unknown | Closure_approximation _ | Block_approximation _ ->
+            ());
         let rec filter_inlinable approx =
           match (approx : value_approximation) with
-          | Value_unknown | Closure_approximation (_, _, Metadata_only _) ->
+          | Value_unknown | Value_symbol _
+          | Closure_approximation (_, _, Metadata_only _) ->
             approx
           | Block_approximation approxs ->
             let approxs = Array.map filter_inlinable approxs in
@@ -307,12 +318,25 @@ module Env = struct
     then t
     else add_value_approximation t name (Block_approximation approxs)
 
+  let value_approximation t simple =
+    Simple.pattern_match' simple
+      ~const:(fun _ -> Value_approximation.Value_unknown)
+      ~var:(fun var ~coercion:_ ->
+        try Name.Map.find (Name.var var) t.value_approximations
+        with Not_found -> Value_approximation.Value_unknown)
+      ~symbol:(fun symbol ~coercion:_ ->
+        Value_approximation.Value_symbol symbol)
+
   let find_value_approximation t simple =
     Simple.pattern_match simple
       ~const:(fun _ -> Value_approximation.Value_unknown)
       ~name:(fun name ~coercion:_ ->
-        try Name.Map.find name t.value_approximations
-        with Not_found ->
+        match Name.Map.find name t.value_approximations with
+        | Value_symbol symbol -> t.approximation_for_external_symbol symbol
+        | (Value_unknown | Block_approximation _ | Closure_approximation _) as
+          approx ->
+          approx
+        | exception Not_found ->
           Name.pattern_match name
             ~var:(fun _ -> Value_approximation.Value_unknown)
             ~symbol:t.approximation_for_external_symbol)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -631,22 +631,19 @@ end
 module Let_cont_with_acc = struct
   let create_non_recursive acc cont handler ~body ~free_names_of_body
       ~cost_metrics_of_handler =
-    match Name_occurrences.count_continuation free_names_of_body cont with
-    | Zero when not (Continuation_handler.is_exn_handler handler) -> acc, body
-    | _ ->
-      let acc =
-        Acc.increment_metrics
-          (Cost_metrics.increase_due_to_let_cont_non_recursive
-             ~cost_metrics_of_handler)
-          acc
-      in
-      let expr =
-        (* This function only uses continuations of [free_names_of_body] *)
-        Let_cont.create_non_recursive cont handler ~body
-          ~free_names_of_body:(Known free_names_of_body)
-      in
-      let acc = Acc.remove_continuation_from_free_names cont acc in
-      acc, expr
+    let acc =
+      Acc.increment_metrics
+        (Cost_metrics.increase_due_to_let_cont_non_recursive
+           ~cost_metrics_of_handler)
+        acc
+    in
+    let expr =
+      (* This function only uses continuations of [free_names_of_body] *)
+      Let_cont.create_non_recursive cont handler ~body
+        ~free_names_of_body:(Known free_names_of_body)
+    in
+    let acc = Acc.remove_continuation_from_free_names cont acc in
+    acc, expr
 
   let create_recursive acc handlers ~body ~cost_metrics_of_handlers =
     let acc =
@@ -696,17 +693,22 @@ module Let_cont_with_acc = struct
     let free_names_of_body, acc, body =
       Acc.eval_branch_free_names acc ~f:body
     in
+    let body_acc = acc in
     let cost_metrics_of_handler, handler_free_names, acc, handler =
       Acc.measure_cost_metrics acc ~f:(fun acc ->
           let acc, handler = handler acc in
           Continuation_handler_with_acc.create acc handler_params ~handler
             ~is_exn_handler)
     in
-    (* [create_non_recursive] assumes [acc] contains free names of the body *)
-    let acc, expr =
-      create_non_recursive
-        (Acc.with_free_names free_names_of_body acc)
-        cont handler ~body ~free_names_of_body ~cost_metrics_of_handler
-    in
-    Acc.add_free_names handler_free_names acc, expr
+    match Name_occurrences.count_continuation free_names_of_body cont with
+    | Zero when not (Continuation_handler.is_exn_handler handler) ->
+      Acc.with_free_names free_names_of_body body_acc, body
+    | _ ->
+      (* [create_non_recursive] assumes [acc] contains free names of the body *)
+      let acc, expr =
+        create_non_recursive
+          (Acc.with_free_names free_names_of_body acc)
+          cont handler ~body ~free_names_of_body ~cost_metrics_of_handler
+      in
+      Acc.add_free_names handler_free_names acc, expr
 end

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -121,6 +121,8 @@ module Inlining = struct
 end
 
 module Env = struct
+  type value_approximation = Code_or_metadata.t Value_approximation.t
+
   type t =
     { variables : Variable.t Ident.Map.t;
       globals : Symbol.t Numeric_types.Int.Map.t;
@@ -128,9 +130,8 @@ module Env = struct
       current_unit_id : Ident.t;
       current_depth : Variable.t option;
       symbol_for_global : Ident.t -> Symbol.t;
-      value_approximations : Code.t Value_approximation.t Name.Map.t;
-      approximation_for_external_symbol :
-        Symbol.t -> Code.t Value_approximation.t;
+      value_approximations : value_approximation Name.Map.t;
+      approximation_for_external_symbol : Symbol.t -> value_approximation;
       big_endian : bool
     }
 
@@ -150,18 +151,21 @@ module Env = struct
       | exception Not_found ->
         let approx = Flambda_cmx.load_symbol_approx loader symbol in
         let rec filter_inlinable approx =
-          match (approx : Code.t Value_approximation.t) with
-          | Value_unknown | Closure_approximation (_, None) -> approx
+          match (approx : value_approximation) with
+          | Value_unknown | Closure_approximation (_, Metadata_only _) -> approx
           | Block_approximation approxs ->
             let approxs = Array.map filter_inlinable approxs in
             Value_approximation.Block_approximation approxs
-          | Closure_approximation (code_id, Some code) -> (
+          | Closure_approximation (code_id, Code_present code) -> (
             match
               Inlining.definition_inlining_decision (Code.inline code)
                 (Code.cost_metrics code)
             with
             | Attribute_inline | Small_function _ -> approx
-            | _ -> Value_approximation.Closure_approximation (code_id, None))
+            | _ ->
+              Value_approximation.Closure_approximation
+                ( code_id,
+                  Code_or_metadata.(remember_only_metadata (create code)) ))
         in
         let approx = filter_inlinable approx in
         externals := Symbol.Map.add symbol approx !externals;
@@ -320,13 +324,13 @@ end
 
 module Acc = struct
   type continuation_application =
-    | Trackable_arguments of Code.t Value_approximation.t list
+    | Trackable_arguments of Env.value_approximation list
     | Untrackable
 
   type t =
     { declared_symbols : (Symbol.t * Static_const.t) list;
       declared_static_sets_of_closures :
-        ((Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t
+        ((Symbol.t * Env.value_approximation) Closure_id.Lmap.t
         * Flambda.Set_of_closures.t)
         list;
       shareable_constants : Symbol.t Static_const.Map.t;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -326,7 +326,9 @@ module Acc = struct
   type t =
     { declared_symbols : (Symbol.t * Static_const.t) list;
       declared_static_sets_of_closures :
-        (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list;
+        ((Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t
+        * Flambda.Set_of_closures.t)
+        list;
       shareable_constants : Symbol.t Static_const.Map.t;
       code : Code.t Code_id.Map.t;
       free_names : Name_occurrences.t;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -58,9 +58,7 @@ module IR = struct
       continuation : Continuation.t;
       exn_continuation : exn_continuation;
       loc : Lambda.scoped_location;
-      tailcall : Lambda.tailcall_attribute;
       inlined : Lambda.inlined_attribute;
-      specialised : Lambda.specialise_attribute;
       probe : Lambda.probe
     }
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -88,6 +88,38 @@ module IR = struct
         args
 end
 
+module Inlining = struct
+  type inlinable_result =
+    | Not_inlinable
+    | Inlinable of Code.t
+
+  let threshold () =
+    let inline_threshold =
+      Clflags.Float_arg_helper.get ~key:0 !Clflags.inline_threshold
+    in
+    let magic_scale_constant = 8. in
+    int_of_float (inline_threshold *. magic_scale_constant)
+
+  let definition_inlining_decision inline cost_metrics =
+    let inline_threshold = threshold () in
+    let code_size = Cost_metrics.size cost_metrics in
+    match (inline : Inline_attribute.t) with
+    | Never_inline ->
+      Function_decl_inlining_decision_type.Never_inline_attribute
+    | Always_inline | Available_inline ->
+      Function_decl_inlining_decision_type.Attribute_inline
+    | _ ->
+      if Code_size.to_int code_size <= inline_threshold
+      then
+        Function_decl_inlining_decision_type.Small_function
+          { size = code_size;
+            small_function_size = Code_size.of_int inline_threshold
+          }
+      else
+        Function_decl_inlining_decision_type.Function_body_too_large
+          (Code_size.of_int inline_threshold)
+end
+
 module Env = struct
   type t =
     { variables : Variable.t Ident.Map.t;
@@ -117,6 +149,21 @@ module Env = struct
       | approx -> approx
       | exception Not_found ->
         let approx = Flambda_cmx.load_symbol_approx loader symbol in
+        let rec filter_inlinable approx =
+          match (approx : Code.t Value_approximation.t) with
+          | Value_unknown | Closure_approximation (_, None) -> approx
+          | Block_approximation approxs ->
+            let approxs = Array.map filter_inlinable approxs in
+            Value_approximation.Block_approximation approxs
+          | Closure_approximation (code_id, Some code) -> (
+            match
+              Inlining.definition_inlining_decision (Code.inline code)
+                (Code.cost_metrics code)
+            with
+            | Attribute_inline | Small_function _ -> approx
+            | _ -> Value_approximation.Closure_approximation (code_id, None))
+        in
+        let approx = filter_inlinable approx in
         externals := Symbol.Map.add symbol approx !externals;
         approx
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -89,11 +89,6 @@ module IR = struct
 end
 
 module Env = struct
-  type value_approximation =
-    | Value_unknown
-    | Closure_approximation of Code_id.t * Code.t option
-    | Block_approximation of value_approximation array
-
   type t =
     { variables : Variable.t Ident.Map.t;
       globals : Symbol.t Numeric_types.Int.Map.t;
@@ -101,7 +96,7 @@ module Env = struct
       current_unit_id : Ident.t;
       current_depth : Variable.t option;
       symbol_for_global : Ident.t -> Symbol.t;
-      value_approximations : value_approximation Name.Map.t;
+      value_approximations : Code.t Value_approximation.t Name.Map.t;
       big_endian : bool
     }
 
@@ -227,7 +222,7 @@ module Env = struct
     Ident.Map.find id t.simples_to_substitute
 
   let add_value_approximation t name approx =
-    if approx = Value_unknown
+    if Value_approximation.is_unknown approx
     then t
     else
       { t with
@@ -238,16 +233,16 @@ module Env = struct
     add_value_approximation t name (Closure_approximation (code_id, approx))
 
   let add_block_approximation t name approxs =
-    if Array.for_all (( = ) Value_unknown) approxs
+    if Array.for_all Value_approximation.is_unknown approxs
     then t
     else add_value_approximation t name (Block_approximation approxs)
 
   let find_value_approximation t simple =
     Simple.pattern_match simple
-      ~const:(fun _ -> Value_unknown)
+      ~const:(fun _ -> Value_approximation.Value_unknown)
       ~name:(fun name ~coercion:_ ->
         try Name.Map.find name t.value_approximations
-        with Not_found -> Value_unknown)
+        with Not_found -> Value_approximation.Value_unknown)
 
   let add_approximation_alias t name alias =
     match find_value_approximation t (Simple.name name) with
@@ -257,7 +252,7 @@ end
 
 module Acc = struct
   type continuation_application =
-    | Trackable_arguments of Env.value_approximation list
+    | Trackable_arguments of Code.t Value_approximation.t list
     | Untrackable
 
   type t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -150,11 +150,12 @@ module Env = struct
         let approx = Flambda_cmx.load_symbol_approx loader symbol in
         let rec filter_inlinable approx =
           match (approx : value_approximation) with
-          | Value_unknown | Closure_approximation (_, Metadata_only _) -> approx
+          | Value_unknown | Closure_approximation (_, _, Metadata_only _) ->
+            approx
           | Block_approximation approxs ->
             let approxs = Array.map filter_inlinable approxs in
             Value_approximation.Block_approximation approxs
-          | Closure_approximation (code_id, Code_present code) -> (
+          | Closure_approximation (code_id, closure_id, Code_present code) -> (
             match
               Inlining.definition_inlining_decision (Code.inline code)
                 (Code.cost_metrics code)
@@ -163,6 +164,7 @@ module Env = struct
             | _ ->
               Value_approximation.Closure_approximation
                 ( code_id,
+                  closure_id,
                   Code_or_metadata.(remember_only_metadata (create code)) ))
         in
         let approx = filter_inlinable approx in
@@ -296,8 +298,9 @@ module Env = struct
         value_approximations = Name.Map.add name approx t.value_approximations
       }
 
-  let add_closure_approximation t name (code_id, approx) =
-    add_value_approximation t name (Closure_approximation (code_id, approx))
+  let add_closure_approximation t name (code_id, closure_id, approx) =
+    add_value_approximation t name
+      (Closure_approximation (code_id, closure_id, approx))
 
   let add_block_approximation t name approxs =
     if Array.for_all Value_approximation.is_unknown approxs

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -325,6 +325,8 @@ module Acc = struct
 
   type t =
     { declared_symbols : (Symbol.t * Static_const.t) list;
+      declared_static_sets_of_closures :
+        (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list;
       shareable_constants : Symbol.t Static_const.Map.t;
       code : Code.t Code_id.Map.t;
       free_names : Name_occurrences.t;
@@ -347,6 +349,7 @@ module Acc = struct
 
   let create ~symbol_for_global =
     { declared_symbols = [];
+      declared_static_sets_of_closures = [];
       shareable_constants = Static_const.Map.empty;
       code = Code_id.Map.empty;
       free_names = Name_occurrences.empty;
@@ -358,6 +361,8 @@ module Acc = struct
 
   let declared_symbols t = t.declared_symbols
 
+  let declared_static_sets_of_closures t = t.declared_static_sets_of_closures
+
   let shareable_constants t = t.shareable_constants
 
   let code t = t.code
@@ -367,6 +372,12 @@ module Acc = struct
   let add_declared_symbol ~symbol ~constant t =
     let declared_symbols = (symbol, constant) :: t.declared_symbols in
     { t with declared_symbols }
+
+  let add_declared_set_of_closures ~symbols ~set_of_closures t =
+    { t with
+      declared_static_sets_of_closures =
+        (symbols, set_of_closures) :: t.declared_static_sets_of_closures
+    }
 
   let add_shareable_constant ~symbol ~constant t =
     let shareable_constants =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -175,7 +175,10 @@ module Env = struct
       current_unit_id = Compilation_unit.get_persistent_ident compilation_unit;
       current_depth = None;
       value_approximations = Name.Map.empty;
-      approximation_for_external_symbol = approximation_loader cmx_loader;
+      approximation_for_external_symbol =
+        (if Flambda_features.classic_mode ()
+        then approximation_loader cmx_loader
+        else fun _symbol -> Value_approximation.Value_unknown);
       symbol_for_global;
       big_endian
     }

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -81,7 +81,11 @@ end
 module Env : sig
   type t
 
-  val create : symbol_for_global:(Ident.t -> Symbol.t) -> big_endian:bool -> t
+  val create :
+    symbol_for_global:(Ident.t -> Symbol.t) ->
+    big_endian:bool ->
+    cmx_loader:Flambda_cmx.loader ->
+    t
 
   val clear_local_bindings : t -> t
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -142,6 +142,8 @@ module Env : sig
 
   val add_approximation_alias : t -> Name.t -> Name.t -> t
 
+  val value_approximation : t -> Simple.t -> value_approximation
+
   val find_value_approximation : t -> Simple.t -> value_approximation
 
   val current_depth : t -> Variable.t option

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -136,7 +136,7 @@ module Env : sig
   val add_value_approximation : t -> Name.t -> value_approximation -> t
 
   val add_closure_approximation :
-    t -> Name.t -> Code_id.t * Code_or_metadata.t -> t
+    t -> Name.t -> Code_id.t * Closure_id.t * Code_or_metadata.t -> t
 
   val add_block_approximation : t -> Name.t -> value_approximation array -> t
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -92,6 +92,8 @@ end
     values during closure conversion, and similarly for static exception
     identifiers. *)
 module Env : sig
+  type value_approximation = Code_or_metadata.t Value_approximation.t
+
   type t
 
   val create :
@@ -133,16 +135,16 @@ module Env : sig
 
   val find_simple_to_substitute_exn : t -> Ident.t -> Simple.t
 
-  val add_value_approximation : t -> Name.t -> Code.t Value_approximation.t -> t
+  val add_value_approximation : t -> Name.t -> value_approximation -> t
 
-  val add_closure_approximation : t -> Name.t -> Code_id.t * Code.t option -> t
+  val add_closure_approximation :
+    t -> Name.t -> Code_id.t * Code_or_metadata.t -> t
 
-  val add_block_approximation :
-    t -> Name.t -> Code.t Value_approximation.t array -> t
+  val add_block_approximation : t -> Name.t -> value_approximation array -> t
 
   val add_approximation_alias : t -> Name.t -> Name.t -> t
 
-  val find_value_approximation : t -> Simple.t -> Code.t Value_approximation.t
+  val find_value_approximation : t -> Simple.t -> value_approximation
 
   val current_depth : t -> Variable.t option
 
@@ -165,7 +167,7 @@ module Acc : sig
 
   val declared_static_sets_of_closures :
     t ->
-    ((Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t
+    ((Symbol.t * Env.value_approximation) Closure_id.Lmap.t
     * Flambda.Set_of_closures.t)
     list
 
@@ -182,7 +184,7 @@ module Acc : sig
   val add_declared_symbol : symbol:Symbol.t -> constant:Static_const.t -> t -> t
 
   val add_declared_set_of_closures :
-    symbols:(Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t ->
+    symbols:(Symbol.t * Env.value_approximation) Closure_id.Lmap.t ->
     set_of_closures:Flambda.Set_of_closures.t ->
     t ->
     t
@@ -199,7 +201,7 @@ module Acc : sig
   val remove_continuation_from_free_names : Continuation.t -> t -> t
 
   val continuation_known_arguments :
-    cont:Continuation.t -> t -> Code.t Value_approximation.t list option
+    cont:Continuation.t -> t -> Env.value_approximation list option
 
   val with_free_names : Name_occurrences.t -> t -> t
 
@@ -311,7 +313,7 @@ module Apply_cont_with_acc : sig
   val create :
     Acc.t ->
     ?trap_action:Trap_action.t ->
-    ?args_approx:Code.t Value_approximation.t list ->
+    ?args_approx:Env.value_approximation list ->
     Continuation.t ->
     args:Simple.t list ->
     dbg:Debuginfo.t ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -164,7 +164,10 @@ module Acc : sig
   val declared_symbols : t -> (Symbol.t * Static_const.t) list
 
   val declared_static_sets_of_closures :
-    t -> (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list
+    t ->
+    ((Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t
+    * Flambda.Set_of_closures.t)
+    list
 
   val shareable_constants : t -> Symbol.t Static_const.Map.t
 
@@ -179,7 +182,7 @@ module Acc : sig
   val add_declared_symbol : symbol:Symbol.t -> constant:Static_const.t -> t -> t
 
   val add_declared_set_of_closures :
-    symbols:Symbol.t Closure_id.Lmap.t ->
+    symbols:(Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t ->
     set_of_closures:Flambda.Set_of_closures.t ->
     t ->
     t

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -163,6 +163,9 @@ module Acc : sig
 
   val declared_symbols : t -> (Symbol.t * Static_const.t) list
 
+  val declared_static_sets_of_closures :
+    t -> (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list
+
   val shareable_constants : t -> Symbol.t Static_const.Map.t
 
   val code : t -> Code.t Code_id.Map.t
@@ -174,6 +177,12 @@ module Acc : sig
   val with_seen_a_function : t -> bool -> t
 
   val add_declared_symbol : symbol:Symbol.t -> constant:Static_const.t -> t -> t
+
+  val add_declared_set_of_closures :
+    symbols:Symbol.t Closure_id.Lmap.t ->
+    set_of_closures:Flambda.Set_of_closures.t ->
+    t ->
+    t
 
   val add_shareable_constant :
     symbol:Symbol.t -> constant:Static_const.t -> t -> t

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -75,6 +75,19 @@ module IR : sig
   val print_named : Format.formatter -> named -> unit
 end
 
+module Inlining : sig
+  type inlinable_result =
+    | Not_inlinable
+    | Inlinable of Code.t
+
+  val threshold : unit -> int
+
+  val definition_inlining_decision :
+    Inline_attribute.t ->
+    Cost_metrics.t ->
+    Function_decl_inlining_decision_type.t
+end
+
 (** Used to remember which [Variable.t] values correspond to which [Ident.t]
     values during closure conversion, and similarly for static exception
     identifiers. *)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -79,11 +79,6 @@ end
     values during closure conversion, and similarly for static exception
     identifiers. *)
 module Env : sig
-  type value_approximation =
-    | Value_unknown
-    | Closure_approximation of Code_id.t * Code.t option
-    | Block_approximation of value_approximation array
-
   type t
 
   val create : symbol_for_global:(Ident.t -> Symbol.t) -> big_endian:bool -> t
@@ -121,15 +116,15 @@ module Env : sig
 
   val find_simple_to_substitute_exn : t -> Ident.t -> Simple.t
 
-  val add_value_approximation : t -> Name.t -> value_approximation -> t
+  val add_value_approximation : t -> Name.t -> Code.t Value_approximation.t -> t
 
   val add_closure_approximation : t -> Name.t -> Code_id.t * Code.t option -> t
 
-  val add_block_approximation : t -> Name.t -> value_approximation array -> t
+  val add_block_approximation : t -> Name.t -> Code.t Value_approximation.t array -> t
 
   val add_approximation_alias : t -> Name.t -> Name.t -> t
 
-  val find_value_approximation : t -> Simple.t -> value_approximation
+  val find_value_approximation : t -> Simple.t -> Code.t Value_approximation.t
 
   val current_depth : t -> Variable.t option
 
@@ -174,7 +169,7 @@ module Acc : sig
   val remove_continuation_from_free_names : Continuation.t -> t -> t
 
   val continuation_known_arguments :
-    cont:Continuation.t -> t -> Env.value_approximation list option
+    cont:Continuation.t -> t -> Code.t Value_approximation.t list option
 
   val with_free_names : Name_occurrences.t -> t -> t
 
@@ -286,7 +281,7 @@ module Apply_cont_with_acc : sig
   val create :
     Acc.t ->
     ?trap_action:Trap_action.t ->
-    ?args_approx:Env.value_approximation list ->
+    ?args_approx:Code.t Value_approximation.t list ->
     Continuation.t ->
     args:Simple.t list ->
     dbg:Debuginfo.t ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -60,9 +60,7 @@ module IR : sig
       continuation : Continuation.t;
       exn_continuation : exn_continuation;
       loc : Lambda.scoped_location;
-      tailcall : Lambda.tailcall_attribute;
       inlined : Lambda.inlined_attribute;
-      specialised : Lambda.specialise_attribute;
       probe : Lambda.probe
     }
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -120,7 +120,8 @@ module Env : sig
 
   val add_closure_approximation : t -> Name.t -> Code_id.t * Code.t option -> t
 
-  val add_block_approximation : t -> Name.t -> Code.t Value_approximation.t array -> t
+  val add_block_approximation :
+    t -> Name.t -> Code.t Value_approximation.t array -> t
 
   val add_approximation_alias : t -> Name.t -> Name.t -> t
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1535,9 +1535,9 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~scrutinee
       switch_expr acc ccenv)
     k_exn
 
-let lambda_to_flambda ~symbol_for_global ~big_endian ~module_ident
+let lambda_to_flambda ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
     ~module_block_size_in_words (lam : Lambda.lambda) :
-    Flambda_unit.t * Exported_code.t =
+    Flambda_unit.t * Exported_code.t * Flambda_cmx_format.t option =
   let current_unit_id =
     Compilation_unit.get_persistent_ident (Compilation_unit.get_current_exn ())
   in
@@ -1549,6 +1549,6 @@ let lambda_to_flambda ~symbol_for_global ~big_endian ~module_ident
   let toplevel acc ccenv =
     cps_tail acc env ccenv lam return_continuation exn_continuation
   in
-  CC.close_program ~symbol_for_global ~big_endian ~module_ident
+  CC.close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
     ~module_block_size_in_words ~program:toplevel
     ~prog_return_cont:return_continuation ~exn_continuation

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -649,9 +649,9 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
       { ap_func;
         ap_args;
         ap_loc;
-        ap_tailcall;
+        ap_tailcall = _;
         ap_inlined;
-        ap_specialised;
+        ap_specialised = _;
         ap_probe
       } ->
     cps_non_tail_list acc env ccenv ap_args
@@ -675,9 +675,7 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
                     exn_continuation;
                     args;
                     loc = ap_loc;
-                    tailcall = ap_tailcall;
                     inlined = ap_inlined;
-                    specialised = ap_specialised;
                     probe = ap_probe
                   }
                 in
@@ -856,9 +854,7 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
                         exn_continuation;
                         args;
                         loc;
-                        tailcall = Default_tailcall;
                         inlined = Default_inlined;
-                        specialised = Default_specialise;
                         probe = None
                       }
                     in
@@ -978,9 +974,7 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
                 exn_continuation;
                 args;
                 loc = apply.ap_loc;
-                tailcall = apply.ap_tailcall;
                 inlined = apply.ap_inlined;
-                specialised = apply.ap_specialised;
                 probe = apply.ap_probe
               }
             in
@@ -1162,9 +1156,7 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
                     exn_continuation;
                     args;
                     loc;
-                    tailcall = Default_tailcall;
                     inlined = Default_inlined;
-                    specialised = Default_specialise;
                     probe = None
                   }
                 in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
@@ -21,7 +21,8 @@
 val lambda_to_flambda :
   symbol_for_global:(?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
   big_endian:bool ->
+  cmx_loader:Flambda_cmx.loader ->
   module_ident:Ident.t ->
   module_block_size_in_words:int ->
   Lambda.lambda ->
-  Flambda_unit.t * Exported_code.t
+  Flambda_unit.t * Exported_code.t * Flambda_cmx_format.t option

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -24,52 +24,13 @@ type simplify_result =
     all_code : Exported_code.t
   }
 
-let all_predefined_exception_symbols ~symbol_for_global =
-  Predef.all_predef_exns
-  |> List.map (fun ident ->
-         symbol_for_global
-           ?comp_unit:(Some (Compilation_unit.predefined_exception ()))
-           ident)
-  |> Symbol.Set.of_list
-
-let predefined_exception_typing_env ~symbol_for_global ~resolver
-    ~get_imported_names =
-  let comp_unit = Compilation_unit.get_current_exn () in
-  Compilation_unit.set_current (Compilation_unit.predefined_exception ());
-  let typing_env =
-    Symbol.Set.fold
-      (fun sym typing_env ->
-        TE.add_definition typing_env (Bound_name.symbol sym) K.value)
-      (all_predefined_exception_symbols ~symbol_for_global)
-      (TE.create ~resolver ~get_imported_names)
-  in
-  Compilation_unit.set_current comp_unit;
-  typing_env
-
-let run ~symbol_for_global ~get_global_info ~round unit =
+let run ~cmx_loader ~round unit =
   let return_continuation = FU.return_continuation unit in
   let exn_continuation = FU.exn_continuation unit in
   let module_symbol = FU.module_symbol unit in
-  let imported_names = ref Name.Set.empty in
-  let imported_code = ref Exported_code.empty in
-  let imported_units = ref Compilation_unit.Map.empty in
-  let resolver comp_unit =
-    Flambda_cmx.load_cmx_file_contents ~get_global_info comp_unit
-      ~imported_names ~imported_code ~imported_units
-  in
-  let get_imported_names () = !imported_names in
-  let get_imported_code () = !imported_code in
-  let predefined_exception_typing_env =
-    predefined_exception_typing_env ~symbol_for_global ~resolver
-      ~get_imported_names
-  in
-  imported_units
-    := Compilation_unit.Map.add
-         (Compilation_unit.predefined_exception ())
-         (Some predefined_exception_typing_env) !imported_units;
-  imported_names
-    := Name.Set.union !imported_names
-         (TE.name_domain predefined_exception_typing_env);
+  let resolver = Flambda_cmx.load_cmx_file_contents cmx_loader in
+  let get_imported_names = Flambda_cmx.get_imported_names cmx_loader in
+  let get_imported_code = Flambda_cmx.get_imported_code cmx_loader in
   let denv =
     DE.create ~round ~resolver ~get_imported_names ~get_imported_code
       ~float_const_prop:(Flambda_features.float_const_prop ())
@@ -103,7 +64,7 @@ let run ~symbol_for_global ~get_global_info ~round unit =
   in
   let all_code =
     Exported_code.merge (UA.all_code uacc)
-      (Exported_code.mark_as_imported !imported_code)
+      (Exported_code.mark_as_imported (get_imported_code ()))
   in
   let used_closure_vars =
     UA.name_occurrences uacc |> Name_occurrences.closure_vars

--- a/middle_end/flambda2/simplify/simplify.mli
+++ b/middle_end/flambda2/simplify/simplify.mli
@@ -29,8 +29,7 @@ type simplify_result = private
   }
 
 val run :
-  symbol_for_global:(?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
-  get_global_info:(Compilation_unit.t -> Flambda_cmx_format.t option) ->
+  cmx_loader:Flambda_cmx.loader ->
   round:int ->
   Flambda_unit.t ->
   simplify_result

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -682,15 +682,15 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
      call in order to correctly adopt to the change in calling convention. *)
   let call_must_be_detupled is_function_decl_tupled =
     match call with
-    | Direct _ | Indirect_known_arity _ ->
-      (* In these cases, the calling convention already used in the application
+    | Direct _ ->
+      (* In this case, the calling convention already used in the application
          being simplified is that of the code actually called. Thus we must not
          detuple the function. *)
       false
-      (* In the indirect case, the calling convention used currently is the
+      (* In the indirect cases, the calling convention used currently is the
          generic one. Thus we need to detuple the call iff the function
          declaration is tupled. *)
-    | Indirect_unknown_arity -> is_function_decl_tupled
+    | Indirect_known_arity _ | Indirect_unknown_arity -> is_function_decl_tupled
   in
   let type_unavailable () =
     if not (DA.do_not_rebuild_terms dacc)

--- a/middle_end/flambda2/tests/tools/dune
+++ b/middle_end/flambda2/tests/tools/dune
@@ -4,4 +4,4 @@
   (flags (:standard -principal -nostdlib))
   (libraries
    stdlib runtime_native ocamlcommon ocamloptcomp
-   flambda2 flambda2_compare flambda2_parser flambda2_terms))
+   flambda2 flambda2_compare flambda2_parser flambda2_terms flambda2_cmx))

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -51,7 +51,9 @@ let run_expect_test ~symbol_for_global ~get_global_info ~extension ~filename
     Fexpr_to_flambda.conv ~symbol_for_global ~module_ident before
   in
   check_invariants before_fl;
-  let cmx_loader = Flambda_cmx.create_loader ~symbol_for_global ~get_global_info in
+  let cmx_loader =
+    Flambda_cmx.create_loader ~symbol_for_global ~get_global_info
+  in
   let { Simplify.unit = actual_fl; _ } =
     Simplify.run ~cmx_loader ~round:0 before_fl
   in

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -51,8 +51,9 @@ let run_expect_test ~symbol_for_global ~get_global_info ~extension ~filename
     Fexpr_to_flambda.conv ~symbol_for_global ~module_ident before
   in
   check_invariants before_fl;
+  let cmx_loader = Flambda_cmx.create_loader ~symbol_for_global ~get_global_info in
   let { Simplify.unit = actual_fl; _ } =
-    Simplify.run ~symbol_for_global ~get_global_info ~round:0 before_fl
+    Simplify.run ~cmx_loader ~round:0 before_fl
   in
   let expected_fl =
     Fexpr_to_flambda.conv ~symbol_for_global ~module_ident expected

--- a/middle_end/flambda2/tests/tools/import.ml
+++ b/middle_end/flambda2/tests/tools/import.ml
@@ -3,3 +3,4 @@ include Flambda2_identifiers
 include Flambda2_terms
 include Flambda2_parser
 include Flambda2_simplify
+include Flambda2_cmx

--- a/middle_end/flambda2/types/dune
+++ b/middle_end/flambda2/types/dune
@@ -34,6 +34,7 @@
   ocamlcommon
   flambda2_algorithms
   flambda2_bound_identifiers
+  flambda2_classic_mode_types
   flambda2_identifiers
   flambda2_kinds
   flambda2_lattices

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -280,6 +280,8 @@ end = struct
     let rec type_from_approx approx =
       match (approx : _ Value_approximation.t) with
       | Value_unknown -> MTC.unknown Flambda_kind.value
+      | Value_symbol symbol ->
+        TG.alias_type_of Flambda_kind.value (Simple.symbol symbol)
       | Block_approximation fields ->
         let fields = List.map type_from_approx (Array.to_list fields) in
         MTC.immutable_block ~is_unique:false Tag.zero

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -236,6 +236,9 @@ module Serializable : sig
 
   val create : typing_env -> t
 
+  val create_from_closure_conversion_approx :
+    'a Value_approximation.t Symbol.Map.t -> t
+
   val print : Format.formatter -> t -> unit
 
   val all_ids_for_export : t -> Ids_for_export.t
@@ -267,6 +270,47 @@ end = struct
 
   let create ~defined_symbols ~code_age_relation ~just_after_level
       ~next_binding_time =
+    { defined_symbols; code_age_relation; just_after_level; next_binding_time }
+
+  let create_from_closure_conversion_approx
+      (symbols : _ Value_approximation.t Symbol.Map.t) =
+    let defined_symbols = Symbol.Map.keys symbols in
+    let code_age_relation = Code_age_relation.empty in
+    let next_binding_time = Binding_time.earliest_var in
+    let rec type_from_approx approx =
+      match (approx : _ Value_approximation.t) with
+      | Value_unknown -> MTC.unknown Flambda_kind.value
+      | Block_approximation fields ->
+        let fields = List.map type_from_approx (Array.to_list fields) in
+        MTC.immutable_block ~is_unique:false Tag.zero
+          ~field_kind:Flambda_kind.value ~fields
+      | Closure_approximation (code_id, _code_opt) ->
+        let closure_id =
+          Closure_id.wrap
+            (Compilation_unit.get_current_exn ())
+            (Variable.create (Code_id.name code_id))
+        in
+        let fun_decl =
+          TG.Function_type.create code_id ~rec_info:(MTC.unknown Flambda_kind.rec_info)
+        in
+        let all_function_decls_in_set =
+          Closure_id.Map.singleton closure_id (Or_unknown_or_bottom.Ok fun_decl)
+        in
+        let all_closures_in_set =
+          Closure_id.Map.singleton closure_id
+            (MTC.unknown Flambda_kind.value)
+        in
+        let all_closure_vars_in_set = Var_within_closure.Map.empty in
+        MTC.exactly_this_closure closure_id ~all_function_decls_in_set
+          ~all_closures_in_set ~all_closure_vars_in_set
+    in
+    let just_after_level =
+      Symbol.Map.fold
+        (fun sym approx cached ->
+          Cached_level.add_or_replace_binding cached (Name.symbol sym)
+            (type_from_approx approx) Binding_time.symbols Name_mode.normal)
+        symbols Cached_level.empty
+    in
     { defined_symbols; code_age_relation; just_after_level; next_binding_time }
 
   let [@ocamlformat "disable"] print ppf

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -291,14 +291,14 @@ end = struct
             (Variable.create (Code_id.name code_id))
         in
         let fun_decl =
-          TG.Function_type.create code_id ~rec_info:(MTC.unknown Flambda_kind.rec_info)
+          TG.Function_type.create code_id
+            ~rec_info:(MTC.unknown Flambda_kind.rec_info)
         in
         let all_function_decls_in_set =
           Closure_id.Map.singleton closure_id (Or_unknown_or_bottom.Ok fun_decl)
         in
         let all_closures_in_set =
-          Closure_id.Map.singleton closure_id
-            (MTC.unknown Flambda_kind.value)
+          Closure_id.Map.singleton closure_id (MTC.unknown Flambda_kind.value)
         in
         let all_closure_vars_in_set = Var_within_closure.Map.empty in
         MTC.exactly_this_closure closure_id ~all_function_decls_in_set

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -284,12 +284,7 @@ end = struct
         let fields = List.map type_from_approx (Array.to_list fields) in
         MTC.immutable_block ~is_unique:false Tag.zero
           ~field_kind:Flambda_kind.value ~fields
-      | Closure_approximation (code_id, _code_opt) ->
-        let closure_id =
-          Closure_id.wrap
-            (Compilation_unit.get_current_exn ())
-            (Variable.create (Code_id.name code_id))
-        in
+      | Closure_approximation (code_id, closure_id, _code_or_metadata) ->
         let fun_decl =
           TG.Function_type.create code_id
             ~rec_info:(MTC.unknown Flambda_kind.rec_info)

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -177,6 +177,9 @@ module Serializable : sig
 
   val create : typing_env -> t
 
+  val create_from_closure_conversion_approx :
+    'a Value_approximation.t Symbol.Map.t -> t
+
   val print : Format.formatter -> t -> unit
 
   val to_typing_env :

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -62,45 +62,65 @@ let join ?bound_name central_env ~left_env ~left_ty ~right_env ~right_ty =
 
 let extract_symbol_approx env symbol find_code =
   let rec type_to_approx (ty : t) : _ Value_approximation.t =
-    let expanded = Expand_head.expand_head env ty in
-    match Expand_head.Expanded_type.descr expanded with
-    | Unknown | Bottom -> Value_unknown
-    | Ok
-        ( Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
-        | Naked_nativeint _ | Rec_info _ ) ->
-      Misc.fatal_error
-        "Typing_env.Serializable.to_closure_conversion_approx: Wrong kind"
-    | Ok (Value ty) -> begin
-      match ty with
-      | Array _ | String _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
-      | Boxed_nativeint _ ->
-        Value_unknown
-      | Closures { by_closure_id } -> (
-        match Row_like_for_closures.get_singleton by_closure_id with
-        | None -> Value_unknown
-        | Some ((closure_id, _contents), closures_entry) -> begin
-          match Closures_entry.find_function_type closures_entry closure_id with
-          | Bottom | Unknown -> Value_unknown
-          | Ok function_type ->
-            let code_id = Function_type.code_id function_type in
-            let code_or_meta = find_code code_id in
-            Closure_approximation (code_id, closure_id, code_or_meta)
-        end)
-      | Variant { immediates = Unknown; blocks = _; is_unique = _ }
-      | Variant { immediates = _; blocks = Unknown; is_unique = _ } ->
-        Value_unknown
-      | Variant
-          { immediates = Known imms; blocks = Known blocks; is_unique = _ } ->
-        if Type_grammar.is_obviously_bottom imms
-        then
-          match Row_like_for_blocks.get_singleton blocks with
+    let expand ty : _ Value_approximation.t =
+      let expanded = Expand_head.expand_head env ty in
+      match Expand_head.Expanded_type.descr expanded with
+      | Unknown | Bottom -> Value_unknown
+      | Ok
+          ( Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+          | Naked_nativeint _ | Rec_info _ ) ->
+        Misc.fatal_error
+          "Typing_env.Serializable.to_closure_conversion_approx: Wrong kind"
+      | Ok (Value ty) -> begin
+        match ty with
+        | Array _ | String _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+        | Boxed_nativeint _ ->
+          Value_unknown
+        | Closures { by_closure_id } -> (
+          match Row_like_for_closures.get_singleton by_closure_id with
           | None -> Value_unknown
-          | Some ((_tag, _size), fields) ->
-            let fields =
-              List.map type_to_approx (Product.Int_indexed.components fields)
-            in
-            Block_approximation (Array.of_list fields)
-        else Value_unknown
+          | Some ((closure_id, _contents), closures_entry) -> begin
+            match
+              Closures_entry.find_function_type closures_entry closure_id
+            with
+            | Bottom | Unknown -> Value_unknown
+            | Ok function_type ->
+              let code_id = Function_type.code_id function_type in
+              let code_or_meta = find_code code_id in
+              Closure_approximation (code_id, closure_id, code_or_meta)
+          end)
+        | Variant { immediates = Unknown; blocks = _; is_unique = _ }
+        | Variant { immediates = _; blocks = Unknown; is_unique = _ } ->
+          Value_unknown
+        | Variant
+            { immediates = Known imms; blocks = Known blocks; is_unique = _ } ->
+          if Type_grammar.is_obviously_bottom imms
+          then
+            match Row_like_for_blocks.get_singleton blocks with
+            | None -> Value_unknown
+            | Some ((_tag, _size), fields) ->
+              let fields =
+                List.map type_to_approx (Product.Int_indexed.components fields)
+              in
+              Block_approximation (Array.of_list fields)
+          else Value_unknown
+      end
+    in
+    match Type_grammar.get_alias_exn ty with
+    | exception Not_found -> expand ty
+    | simple -> begin
+      match
+        Typing_env.get_canonical_simple_exn env simple
+          ~min_name_mode:Name_mode.normal
+      with
+      | exception Not_found -> expand ty
+      | simple ->
+        let[@inline always] var _var ~coercion:_ = expand ty in
+        let[@inline always] symbol symbol ~coercion:_ =
+          Value_approximation.Value_symbol symbol
+        in
+        let[@inline always] const _const = expand ty in
+        Simple.pattern_match' simple ~var ~symbol ~const
     end
   in
   let get_symbol_type sym =

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -60,7 +60,7 @@ let join ?bound_name central_env ~left_env ~left_ty ~right_env ~right_ty =
   | Unknown -> unknown_like left_ty
   | Known ty -> ty
 
-let extract_symbol_approx env symbol all_code =
+let extract_symbol_approx env symbol find_code =
   let rec type_to_approx (ty : t) : _ Value_approximation.t =
     let expanded = Expand_head.expand_head env ty in
     match Expand_head.Expanded_type.descr expanded with
@@ -86,7 +86,7 @@ let extract_symbol_approx env symbol all_code =
               let code_id =
                 Function_type.code_id function_type
               in
-              let code = Code_id.Map.find_opt code_id all_code in
+              let code = find_code code_id in
               (* CR vlaviron: Should we fail if [code] is [None] ? *)
               Closure_approximation (code_id, code)
           end)

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -84,7 +84,7 @@ let extract_symbol_approx env symbol find_code =
           | Ok function_type ->
             let code_id = Function_type.code_id function_type in
             let code_or_meta = find_code code_id in
-            Closure_approximation (code_id, code_or_meta)
+            Closure_approximation (code_id, closure_id, code_or_meta)
         end)
       | Variant { immediates = Unknown; blocks = _; is_unique = _ }
       | Variant { immediates = _; blocks = Unknown; is_unique = _ } ->

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -59,3 +59,55 @@ let join ?bound_name central_env ~left_env ~left_ty ~right_env ~right_ty =
   match join ?bound_name join_env left_ty right_ty with
   | Unknown -> unknown_like left_ty
   | Known ty -> ty
+
+let extract_symbol_approx env symbol all_code =
+  let rec type_to_approx (ty : t) : _ Value_approximation.t =
+    let expanded = Expand_head.expand_head env ty in
+    match Expand_head.Expanded_type.descr expanded with
+    | Unknown | Bottom -> Value_unknown
+    | Ok (Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+         | Naked_nativeint _ | Rec_info _) ->
+      Misc.fatal_error
+        "Typing_env.Serializable.to_closure_conversion_approx: Wrong kind"
+    | Ok (Value ty) -> begin
+        match ty with
+        | Array _ | String _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+        | Boxed_nativeint _ ->
+          Value_unknown
+        | Closures { by_closure_id } -> (
+          match Row_like_for_closures.get_singleton by_closure_id with
+          | None -> Value_unknown
+          | Some ((closure_id, _contents), closures_entry) -> begin
+            match
+              Closures_entry.find_function_type closures_entry closure_id
+            with
+            | Bottom | Unknown -> Value_unknown
+            | Ok function_type ->
+              let code_id =
+                Function_type.code_id function_type
+              in
+              let code = Code_id.Map.find_opt code_id all_code in
+              (* CR vlaviron: Should we fail if [code] is [None] ? *)
+              Closure_approximation (code_id, code)
+          end)
+        | Variant { immediates = Unknown; blocks = _; is_unique = _ }
+        | Variant { immediates = _; blocks = Unknown; is_unique = _ } ->
+          Value_unknown
+        | Variant
+            { immediates = Known imms; blocks = Known blocks; is_unique = _ } ->
+          if Type_grammar.is_obviously_bottom imms
+          then
+            match Row_like_for_blocks.get_singleton blocks with
+            | None -> Value_unknown
+            | Some ((_tag, _size), fields) ->
+              let fields =
+                List.map type_to_approx (Product.Int_indexed.components fields)
+              in
+              Block_approximation (Array.of_list fields)
+          else Value_unknown
+      end
+    in
+    let get_symbol_type sym =
+      Typing_env.find env (Name.symbol sym) (Some Flambda_kind.value)
+    in
+    type_to_approx (get_symbol_type symbol)

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -83,9 +83,9 @@ let extract_symbol_approx env symbol find_code =
           | Bottom | Unknown -> Value_unknown
           | Ok function_type ->
             let code_id = Function_type.code_id function_type in
-            let code = find_code code_id in
+            let code_or_meta = find_code code_id in
             (* CR vlaviron: Should we fail if [code] is [None] ? *)
-            Closure_approximation (code_id, code)
+            Closure_approximation (code_id, code_or_meta)
         end)
       | Variant { immediates = Unknown; blocks = _; is_unique = _ }
       | Variant { immediates = _; blocks = Unknown; is_unique = _ } ->

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -84,7 +84,6 @@ let extract_symbol_approx env symbol find_code =
           | Ok function_type ->
             let code_id = Function_type.code_id function_type in
             let code_or_meta = find_code code_id in
-            (* CR vlaviron: Should we fail if [code] is [None] ? *)
             Closure_approximation (code_id, code_or_meta)
         end)
       | Variant { immediates = Unknown; blocks = _; is_unique = _ }

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -656,5 +656,5 @@ val reify :
 val extract_symbol_approx :
   Typing_env.t ->
   Symbol.t ->
-  (Code_id.t -> 'code option) ->
+  (Code_id.t -> 'code) ->
   'code Value_approximation.t

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -653,4 +653,4 @@ val reify :
   t ->
   reification_result
 
-val extract_symbol_approx : Typing_env.t -> Symbol.t -> 'code Code_id.Map.t -> 'code Value_approximation.t
+val extract_symbol_approx : Typing_env.t -> Symbol.t -> (Code_id.t -> 'code option) -> 'code Value_approximation.t

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -653,4 +653,8 @@ val reify :
   t ->
   reification_result
 
-val extract_symbol_approx : Typing_env.t -> Symbol.t -> (Code_id.t -> 'code option) -> 'code Value_approximation.t
+val extract_symbol_approx :
+  Typing_env.t ->
+  Symbol.t ->
+  (Code_id.t -> 'code option) ->
+  'code Value_approximation.t

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -186,6 +186,9 @@ module Typing_env : sig
 
     val create : typing_env -> t
 
+    val create_from_closure_conversion_approx :
+      'a Value_approximation.t Symbol.Map.t -> t
+
     val print : Format.formatter -> t -> unit
 
     val to_typing_env :
@@ -649,3 +652,5 @@ val reify :
   min_name_mode:Name_mode.t ->
   t ->
   reification_result
+
+val extract_symbol_approx : Typing_env.t -> Symbol.t -> 'code Code_id.Map.t -> 'code Value_approximation.t


### PR DESCRIPTION
I've tried out a patch to allow symbol references in approximations. There are a few tricky parts (like the distinction between `Env.value_approximation` and `End.find_value_approximation`), and not everything is strictly necessary, but you might want to see if you can build direct calls to imported functions with that.